### PR TITLE
Add `VREnabled` config, `-vr` arg and Graphics Options checkbox

### DIFF
--- a/d1/include/args.h
+++ b/d1/include/args.h
@@ -60,6 +60,7 @@ typedef struct Arg
 	int SndNoMusic;
 	int SndDisableSdlMixer;
 	int GfxHiresFNTAvailable;
+	int GfxVREnabled;
 #ifdef OGL
 	int OglFixedFont;
 #endif

--- a/d1/main/config.c
+++ b/d1/main/config.c
@@ -65,6 +65,7 @@ static const char ClassicDepthStr[] ="ClassicDepth";
 static const char FPSIndicatorStr[] ="FPSIndicator";
 static const char GrabinputStr[] ="GrabInput";
 static const char BorderlessWindowStr[] ="BorderlessWindow";
+static const char VREnabledStr[] ="VREnabled";
 
 int ReadConfigFile()
 {
@@ -115,6 +116,7 @@ int ReadConfigFile()
 	GameCfg.FPSIndicator = 0;
 	GameCfg.Grabinput = 1;
 	GameCfg.BorderlessWindow = 0;
+	GameCfg.VREnabled = 0;
 
 	infile = PHYSFSX_openReadBuffered("descent.cfg");
 
@@ -228,6 +230,8 @@ int ReadConfigFile()
 				GameCfg.Grabinput = strtol(value, NULL, 10);
 			else if (!strcmp(token, BorderlessWindowStr))
 				GameCfg.BorderlessWindow = strtol(value, NULL, 10);
+			else if (!strcmp(token, VREnabledStr))
+				GameCfg.VREnabled = strtol(value, NULL, 10);
 		}
 		d_free(line);
 	}
@@ -284,6 +288,7 @@ int WriteConfigFile()
 	PHYSFSX_printf(infile, "%s=%i\n", FPSIndicatorStr, GameCfg.FPSIndicator);
 	PHYSFSX_printf(infile, "%s=%i\n", GrabinputStr, GameCfg.Grabinput);
 	PHYSFSX_printf(infile, "%s=%i\n", BorderlessWindowStr, GameCfg.BorderlessWindow);
+	PHYSFSX_printf(infile, "%s=%i\n", VREnabledStr, GameCfg.VREnabled);
 
 	PHYSFS_close(infile);
 

--- a/d1/main/config.h
+++ b/d1/main/config.h
@@ -50,6 +50,7 @@ typedef struct Cfg
 	int Grabinput;
 	int ClassicDepth;
 	int BorderlessWindow;
+	int VREnabled;
 } __pack__ Cfg;
 
 extern struct Cfg GameCfg;

--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -125,6 +125,7 @@ void print_commandline_help()
 
 	printf( "\n Graphics:\n\n");
 	printf( "  -lowresfont                   Force to use LowRes fonts\n");
+	printf( "  -vr                           Enable Virtual Reality mode\n");
 #ifdef    OGL
 	printf( "  -gl_fixedfont                 Do not scale fonts to current resolution\n");
 #endif // OGL
@@ -387,6 +388,8 @@ int main(int argc, char *argv[])
 		con_printf(CON_VERBOSE,"%s%s", TXT_VERBOSE_1, "\n");
 	
 	ReadConfigFile();
+	if (GameArg.GfxVREnabled)
+		GameCfg.VREnabled = 1;
 
 	PHYSFSX_addArchiveContent();
 

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -1226,7 +1226,7 @@ void reticle_config()
 	PlayerCfg.ReticleSize = m[opt_ret_size].value;
 }
 
-int opt_gr_texfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit;
+int opt_gr_texfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit, opt_gr_vr;
 int opt_gr_classicdepth;
 int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 {
@@ -1268,10 +1268,10 @@ int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 void graphics_config()
 {
 #ifdef OGL
-	newmenu_item m[17];
+	newmenu_item m[18];
 	int i = 0;
 #else
-	newmenu_item m[6];
+	newmenu_item m[7];
 #endif
 	int nitems = 0;
 
@@ -1305,6 +1305,8 @@ void graphics_config()
 
 	opt_gr_disablecockpit = nitems;
 	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Disable Cockpit View"; m[nitems].value = PlayerCfg.DisableCockpit; nitems++;
+	opt_gr_vr = nitems;
+	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Virtual Reality (OpenVR)"; m[nitems].value = GameCfg.VREnabled; nitems++;
 #ifdef OGL
 	m[opt_gr_texfilt+GameCfg.TexFilt].value=1;
 #endif
@@ -1333,6 +1335,7 @@ void graphics_config()
 	GameCfg.GammaLevel = m[opt_gr_brightness].value;
 	GameCfg.FPSIndicator = m[opt_gr_fpsindi].value;
 	PlayerCfg.DisableCockpit = m[opt_gr_disablecockpit].value; 
+	GameCfg.VREnabled = m[opt_gr_vr].value;
 
 
 	PlayerCfg.maxFps=atoi(framerate_string);

--- a/d1/misc/args.c
+++ b/d1/misc/args.c
@@ -169,6 +169,7 @@ void ReadCmdArgs(void)
 	// Graphics Options
 
 	GameArg.GfxHiresFNTAvailable	= !FindArg("-lowresfont");
+	GameArg.GfxVREnabled		= FindArg("-vr");
 
 #ifdef OGL
 	// OpenGL Options


### PR DESCRIPTION
### Motivation
- Provide a simple toggle to enable Virtual Reality mode via command line, configuration file, and the in-game graphics UI.
- Persist VR preference across runs using the existing `descent.cfg` mechanism.
- Allow users to force VR mode at launch with a command-line flag.
- Expose the VR setting in the Graphics Options so it can be changed from the menus.

### Description
- Add `VREnabled` to the `Cfg` structure in `d1/main/config.h` and introduce the `VREnabledStr` token in `d1/main/config.c` so the value is read from and written to `descent.cfg` (default `0`).
- Register a new command-line flag by adding `GfxVREnabled` to `d1/include/args.h` and parsing `-vr` in `d1/misc/args.c` to populate `GameArg.GfxVREnabled`.
- Apply the command-line override in `d1/main/inferno.c` so that if `-vr` is present `GameCfg.VREnabled` is set to `1` at startup and add `-vr` to the printed help text.
- Add a checkbox to the Graphics Options menu in `d1/main/menu.c` (`opt_gr_vr`) which reads/writes `GameCfg.VREnabled` so the setting can be toggled in the UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957189cf59c8330b199aa967e15d691)