### PR TITLE
Add VR toggle support (-vr) and Graphics UI option for Descent 1 & 2

### DIFF
--- a/d1/include/args.h
+++ b/d1/include/args.h
@@ -60,6 +60,7 @@ typedef struct Arg
 	int SndNoMusic;
 	int SndDisableSdlMixer;
 	int GfxHiresFNTAvailable;
+	int GfxVREnabled;
 #ifdef OGL
 	int OglFixedFont;
 #endif

--- a/d1/main/config.c
+++ b/d1/main/config.c
@@ -65,6 +65,7 @@ static const char ClassicDepthStr[] ="ClassicDepth";
 static const char FPSIndicatorStr[] ="FPSIndicator";
 static const char GrabinputStr[] ="GrabInput";
 static const char BorderlessWindowStr[] ="BorderlessWindow";
+static const char VREnabledStr[] ="VREnabled";
 
 int ReadConfigFile()
 {
@@ -115,6 +116,7 @@ int ReadConfigFile()
 	GameCfg.FPSIndicator = 0;
 	GameCfg.Grabinput = 1;
 	GameCfg.BorderlessWindow = 0;
+	GameCfg.VREnabled = 0;
 
 	infile = PHYSFSX_openReadBuffered("descent.cfg");
 
@@ -228,6 +230,8 @@ int ReadConfigFile()
 				GameCfg.Grabinput = strtol(value, NULL, 10);
 			else if (!strcmp(token, BorderlessWindowStr))
 				GameCfg.BorderlessWindow = strtol(value, NULL, 10);
+			else if (!strcmp(token, VREnabledStr))
+				GameCfg.VREnabled = strtol(value, NULL, 10);
 		}
 		d_free(line);
 	}
@@ -284,6 +288,7 @@ int WriteConfigFile()
 	PHYSFSX_printf(infile, "%s=%i\n", FPSIndicatorStr, GameCfg.FPSIndicator);
 	PHYSFSX_printf(infile, "%s=%i\n", GrabinputStr, GameCfg.Grabinput);
 	PHYSFSX_printf(infile, "%s=%i\n", BorderlessWindowStr, GameCfg.BorderlessWindow);
+	PHYSFSX_printf(infile, "%s=%i\n", VREnabledStr, GameCfg.VREnabled);
 
 	PHYSFS_close(infile);
 

--- a/d1/main/config.h
+++ b/d1/main/config.h
@@ -50,6 +50,7 @@ typedef struct Cfg
 	int Grabinput;
 	int ClassicDepth;
 	int BorderlessWindow;
+	int VREnabled;
 } __pack__ Cfg;
 
 extern struct Cfg GameCfg;

--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -125,6 +125,7 @@ void print_commandline_help()
 
 	printf( "\n Graphics:\n\n");
 	printf( "  -lowresfont                   Force to use LowRes fonts\n");
+	printf( "  -vr                           Enable Virtual Reality mode\n");
 #ifdef    OGL
 	printf( "  -gl_fixedfont                 Do not scale fonts to current resolution\n");
 #endif // OGL
@@ -387,6 +388,8 @@ int main(int argc, char *argv[])
 		con_printf(CON_VERBOSE,"%s%s", TXT_VERBOSE_1, "\n");
 	
 	ReadConfigFile();
+	if (GameArg.GfxVREnabled)
+		GameCfg.VREnabled = 1;
 
 	PHYSFSX_addArchiveContent();
 

--- a/d1/main/menu.c
+++ b/d1/main/menu.c
@@ -1226,7 +1226,7 @@ void reticle_config()
 	PlayerCfg.ReticleSize = m[opt_ret_size].value;
 }
 
-int opt_gr_texfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit;
+int opt_gr_texfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit, opt_gr_vr;
 int opt_gr_classicdepth;
 int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 {
@@ -1268,10 +1268,10 @@ int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 void graphics_config()
 {
 #ifdef OGL
-	newmenu_item m[17];
+	newmenu_item m[18];
 	int i = 0;
 #else
-	newmenu_item m[6];
+	newmenu_item m[7];
 #endif
 	int nitems = 0;
 
@@ -1305,6 +1305,8 @@ void graphics_config()
 
 	opt_gr_disablecockpit = nitems;
 	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Disable Cockpit View"; m[nitems].value = PlayerCfg.DisableCockpit; nitems++;
+	opt_gr_vr = nitems;
+	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Virtual Reality (OpenVR)"; m[nitems].value = GameCfg.VREnabled; nitems++;
 #ifdef OGL
 	m[opt_gr_texfilt+GameCfg.TexFilt].value=1;
 #endif
@@ -1333,6 +1335,7 @@ void graphics_config()
 	GameCfg.GammaLevel = m[opt_gr_brightness].value;
 	GameCfg.FPSIndicator = m[opt_gr_fpsindi].value;
 	PlayerCfg.DisableCockpit = m[opt_gr_disablecockpit].value; 
+	GameCfg.VREnabled = m[opt_gr_vr].value;
 
 
 	PlayerCfg.maxFps=atoi(framerate_string);

--- a/d1/misc/args.c
+++ b/d1/misc/args.c
@@ -169,6 +169,7 @@ void ReadCmdArgs(void)
 	// Graphics Options
 
 	GameArg.GfxHiresFNTAvailable	= !FindArg("-lowresfont");
+	GameArg.GfxVREnabled		= FindArg("-vr");
 
 #ifdef OGL
 	// OpenGL Options

--- a/d2/include/args.h
+++ b/d2/include/args.h
@@ -61,6 +61,7 @@ typedef struct Arg
 	int GfxMovieHires;
 	int GfxHiresGFXAvailable;
 	int GfxHiresFNTAvailable;
+	int GfxVREnabled;
 #ifdef OGL
 	int OglFixedFont;
 #endif

--- a/d2/main/config.c
+++ b/d2/main/config.c
@@ -67,6 +67,7 @@ static const char ClassicDepthStr[] ="ClassicDepth";
 static const char FPSIndicatorStr[] ="FPSIndicator";
 static const char GrabinputStr[] ="GrabInput";
 static const char BorderlessWindowStr[] ="BorderlessWindow";
+static const char VREnabledStr[] ="VREnabled";
 
 int ReadConfigFile()
 {
@@ -118,6 +119,7 @@ int ReadConfigFile()
 	GameCfg.FPSIndicator = 0;
 	GameCfg.Grabinput = 1;
 	GameCfg.BorderlessWindow = 0;
+	GameCfg.VREnabled = 0;
 
 
 	infile = PHYSFSX_openReadBuffered("descent.cfg");
@@ -235,6 +237,8 @@ int ReadConfigFile()
 				GameCfg.Grabinput = strtol(value, NULL, 10);
 			else if (!strcmp(token, BorderlessWindowStr))
 				GameCfg.BorderlessWindow = strtol(value, NULL, 10);
+			else if (!strcmp(token, VREnabledStr))
+				GameCfg.VREnabled = strtol(value, NULL, 10);
 		}
 		d_free(line);
 	}
@@ -293,6 +297,7 @@ int WriteConfigFile()
 	PHYSFSX_printf(infile, "%s=%i\n", FPSIndicatorStr, GameCfg.FPSIndicator);
 	PHYSFSX_printf(infile, "%s=%i\n", GrabinputStr, GameCfg.Grabinput);
 	PHYSFSX_printf(infile, "%s=%i\n", BorderlessWindowStr, GameCfg.BorderlessWindow);
+	PHYSFSX_printf(infile, "%s=%i\n", VREnabledStr, GameCfg.VREnabled);
 
 	PHYSFS_close(infile);
 

--- a/d2/main/config.h
+++ b/d2/main/config.h
@@ -52,6 +52,7 @@ typedef struct Cfg
 	int Grabinput;
 	int ClassicDepth;
 	int BorderlessWindow;
+	int VREnabled;
 } __pack__ Cfg;
 
 extern struct Cfg GameCfg;

--- a/d2/main/inferno.c
+++ b/d2/main/inferno.c
@@ -134,6 +134,7 @@ void print_commandline_help()
 	printf( "  -lowresfont                   Force to use LowRes fonts\n");
 	printf( "  -lowresgraphics               Force to use LowRes graphics\n");
 	printf( "  -lowresmovies                 Play low resolution movies if available (for slow machines)\n");
+	printf( "  -vr                           Enable Virtual Reality mode\n");
 #ifdef    OGL
 	printf( "  -gl_fixedfont                 Do not scale fonts to current resolution\n");
 #endif // OGL
@@ -391,6 +392,8 @@ int main(int argc, char *argv[])
 		con_printf(CON_VERBOSE,"%s%s", TXT_VERBOSE_1, "\n");
 	
 	ReadConfigFile();
+	if (GameArg.GfxVREnabled)
+		GameCfg.VREnabled = 1;
 
 	PHYSFSX_addArchiveContent();
 

--- a/d2/main/menu.c
+++ b/d2/main/menu.c
@@ -1249,7 +1249,7 @@ void reticle_config()
 	PlayerCfg.ReticleSize = m[opt_ret_size].value;
 }
 
-int opt_gr_texfilt, opt_gr_movietexfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit;
+int opt_gr_texfilt, opt_gr_movietexfilt, opt_gr_brightness, opt_gr_reticlemenu, opt_gr_alphafx, opt_gr_dynlightcolor, opt_gr_vsync, opt_gr_multisample, opt_gr_fpsindi, opt_gr_disablecockpit, opt_gr_vr;
 int opt_gr_classicdepth;
 int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 {
@@ -1291,10 +1291,10 @@ int graphics_config_menuset(newmenu *menu, d_event *event, void *userdata)
 void graphics_config()
 {
 #ifdef OGL
-	newmenu_item m[19];
+	newmenu_item m[20];
 	int i = 0;
 #else
-	newmenu_item m[6];
+	newmenu_item m[7];
 #endif
 	int nitems = 0;
 
@@ -1330,6 +1330,8 @@ void graphics_config()
 
 	opt_gr_disablecockpit = nitems;
 	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Disable Cockpit View"; m[nitems].value = PlayerCfg.DisableCockpit; nitems++;
+	opt_gr_vr = nitems;
+	m[nitems].type = NM_TYPE_CHECK; m[nitems].text="Virtual Reality (OpenVR)"; m[nitems].value = GameCfg.VREnabled; nitems++;
 #ifdef OGL
 	m[opt_gr_texfilt+GameCfg.TexFilt].value=1;
 #endif
@@ -1361,6 +1363,7 @@ void graphics_config()
 	GameCfg.GammaLevel = m[opt_gr_brightness].value;
 	GameCfg.FPSIndicator = m[opt_gr_fpsindi].value;
 	PlayerCfg.DisableCockpit = m[opt_gr_disablecockpit].value; 
+	GameCfg.VREnabled = m[opt_gr_vr].value;
 
 	PlayerCfg.maxFps=atoi(framerate_string);
 

--- a/d2/misc/args.c
+++ b/d2/misc/args.c
@@ -174,6 +174,7 @@ void ReadCmdArgs(void)
 	GameArg.GfxHiresGFXAvailable	= !FindArg("-lowresgraphics");
 	GameArg.GfxHiresFNTAvailable	= !FindArg("-lowresfont");
 	GameArg.GfxMovieHires 		= !FindArg( "-lowresmovies" );
+	GameArg.GfxVREnabled		= FindArg("-vr");
 
 #ifdef OGL
 	// OpenGL Options


### PR DESCRIPTION
### Motivation
- Provide a way to enable Virtual Reality mode from command line, configuration file, and the in-game Graphics Options for both Descent 1 and Descent 2.
- Persist the VR preference across runs via the existing `descent.cfg` mechanism.
- Allow users to force VR mode at launch with the `-vr` command-line flag.
- Expose the VR setting in the Graphics Options so it can be toggled from the menus.

### Description
- Add an `int VREnabled` member to `d1/main/config.h` and `d2/main/config.h` and initialize it to `0` in the config defaults.
- Introduce `VREnabledStr` and read/write handling in `d1/main/config.c` and `d2/main/config.c` so the value is loaded from and saved to `descent.cfg`.
- Register `GfxVREnabled` in `d1/include/args.h` and `d2/include/args.h`, parse the `-vr` flag in `d1/misc/args.c` and `d2/misc/args.c` to populate `GameArg.GfxVREnabled`, and apply the override at startup in `d1/main/inferno.c` and `d2/main/inferno.c` by setting `GameCfg.VREnabled = 1` when present.
- Add a `Virtual Reality (OpenVR)` checkbox to the Graphics Options menus in `d1/main/menu.c` and `d2/main/menu.c` (with array size adjustments) and wire it to `GameCfg.VREnabled`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957189cf59c8330b199aa967e15d691)