### PR TITLE
Render cutscene texture directly to VR quad

### DIFF
--- a/d2/arch/ogl/ogl.c
+++ b/d2/arch/ogl/ogl.c
@@ -1224,7 +1224,7 @@ void gr_flip(void)
 
 	ogl_do_palfx();
 #ifdef USE_OPENVR
-	if (vr_openvr_active() && Screen_mode != SCREEN_GAME)
+	if (vr_openvr_active() && Screen_mode != SCREEN_GAME && Screen_mode != SCREEN_MOVIE)
 		vr_openvr_submit_mono_from_screen(Screen_mode == SCREEN_MOVIE);
 #endif
 	ogl_swap_buffers_internal();

--- a/d2/include/ogl_init.h
+++ b/d2/include/ogl_init.h
@@ -87,7 +87,9 @@ int ogl_init_window(int x, int y);//create a window/switch modes/etc
 #define OGL_FLAG_NOCOLOR (1 << 1)
 #define OGL_FLAG_ALPHA (1 << 31) // not required for ogl_loadbmtexture, since it uses the BM_FLAG_TRANSPARENT, but is needed for ogl_init_texture.
 void ogl_loadbmtexture_f(grs_bitmap *bm, int texfilt);
+void ogl_freetexture(ogl_texture *gltexture);
 void ogl_freebmtexture(grs_bitmap *bm);
+int ogl_loadtexture(unsigned char *data, int dxo, int dyo, ogl_texture *tex, int bm_flags, int data_format, int texfilt);
 
 void ogl_start_frame(void);
 void ogl_end_frame(void);

--- a/d2/include/vr_openvr.h
+++ b/d2/include/vr_openvr.h
@@ -24,6 +24,7 @@ void vr_openvr_bind_eye(int eye);
 void vr_openvr_unbind_eye(void);
 void vr_openvr_submit_eyes(void);
 void vr_openvr_submit_mono_from_screen(int curved);
+void vr_openvr_submit_mono_from_texture(unsigned int texture, float u, float v, int curved);
 
 #ifdef __cplusplus
 }

--- a/d2/main/movie.c
+++ b/d2/main/movie.c
@@ -51,8 +51,10 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "physfsrwops.h"
 #ifdef OGL
 #include "ogl_init.h"
+#include "internal.h"
 #endif
 #include "args.h"
+#include "vr_openvr.h"
 
 extern char CDROM_dir[];
 
@@ -212,6 +214,23 @@ void MovieShowFrame(ubyte *buf, int dstx, int dsty, int bufw, int bufh, int sw, 
 		bufw, bufh, 0, 0, &source_bm,&grd_curcanv->cv_bitmap,GameCfg.MovieTexFilt);
 
 	glEnable (GL_BLEND);
+#ifdef USE_OPENVR
+	if (vr_openvr_active() && Screen_mode == SCREEN_MOVIE)
+	{
+		ogl_texture movie_tex;
+
+		ogl_init_texture(&movie_tex, bufw, bufh, OGL_FLAG_ALPHA);
+		movie_tex.prio = 0.0f;
+		movie_tex.lw = source_bm.bm_rowsize;
+
+		ogl_pal = gr_current_pal;
+		ogl_loadtexture(source_bm.bm_data, 0, 0, &movie_tex, source_bm.bm_flags, 0, GameCfg.MovieTexFilt);
+		ogl_pal = gr_palette;
+
+		vr_openvr_submit_mono_from_texture(movie_tex.handle, movie_tex.u, movie_tex.v, 1);
+		ogl_freetexture(&movie_tex);
+	}
+#endif
 #else
 	gr_bm_ubitbltm(bufw,bufh,dstx,dsty,0,0,&source_bm,&grd_curcanv->cv_bitmap);
 #endif


### PR DESCRIPTION
### Motivation
- Ensure VR displays cutscenes by rendering the movie texture directly to the VR overlay instead of copying the screen backbuffer.
- Preserve correct UV coordinates for textures that are not power-of-two so movie frames map correctly on the VR quad.
- Avoid performing the generic screen-copy VR submission while an in-engine cutscene is playing to prevent redundant copies.

### Description
- Add a new API `vr_openvr_submit_mono_from_texture(unsigned int texture, float u, float v, int curved)` and implement it to render a provided texture to each eye.
- Update quad rendering functions to accept `tex_u_max` and `tex_v_max` parameters and apply those values to texture coordinates in both `vr_openvr_draw_curved_quad` and `vr_openvr_draw_flat_quad`.
- In `MovieShowFrame`, allocate an `ogl_texture`, upload the movie frame with `ogl_loadtexture`, and submit it to VR via `vr_openvr_submit_mono_from_texture` when VR is active, then free the temporary texture.
- Skip the screen-copy VR submission for `SCREEN_MOVIE` by changing the check in `gr_flip` to exclude `SCREEN_MOVIE` so movies use the new direct texture path.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695894e2fa408330aa203911ce215ea0)