### PR TITLE
Render VR menus directly into OpenVR texture

### DIFF
--- a/d2/2d/canvas.c
+++ b/d2/2d/canvas.c
@@ -17,8 +17,11 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "u_mem.h"
 #include "gr.h"
 #include "grdef.h"
+#include "screens.h"
 #ifdef OGL
 #include "ogl_init.h"
+#include "inferno.h"
+#include "vr_openvr.h"
 #endif
 
 grs_canvas * grd_curcanv;    //active canvas
@@ -98,10 +101,14 @@ void gr_free_sub_canvas(grs_canvas *canv)
 
 void gr_set_current_canvas( grs_canvas *canv )
 {
+	if (canv && canv->cv_bitmap.bm_type == BM_OGL && Screen_mode == SCREEN_MENU && vr_openvr_active())
+		vr_openvr_bind_menu();
 	if (canv==NULL)
 		grd_curcanv = &(grd_curscreen->sc_canvas);
 	else
 		grd_curcanv = canv;
+	if (grd_curcanv->cv_bitmap.bm_type != BM_OGL && vr_openvr_active())
+		vr_openvr_unbind_menu();
 }
 
 void gr_clear_canvas(int color)

--- a/d2/arch/ogl/ogl.c
+++ b/d2/arch/ogl/ogl.c
@@ -1225,7 +1225,7 @@ void gr_flip(void)
 	ogl_do_palfx();
 #ifdef USE_OPENVR
 	if (vr_openvr_active() && Screen_mode != SCREEN_GAME && Screen_mode != SCREEN_MOVIE)
-		vr_openvr_submit_mono_from_screen(Screen_mode == SCREEN_MOVIE);
+		vr_openvr_submit_menu(Screen_mode == SCREEN_MOVIE);
 #endif
 	ogl_swap_buffers_internal();
 	glClear(GL_COLOR_BUFFER_BIT);

--- a/d2/include/vr_openvr.h
+++ b/d2/include/vr_openvr.h
@@ -22,9 +22,12 @@ int vr_openvr_current_eye(void);
 void vr_openvr_render_size(int *width, int *height);
 void vr_openvr_bind_eye(int eye);
 void vr_openvr_unbind_eye(void);
+void vr_openvr_bind_menu(void);
+void vr_openvr_unbind_menu(void);
 void vr_openvr_submit_eyes(void);
 void vr_openvr_submit_mono_from_screen(int curved);
 void vr_openvr_submit_mono_from_texture(unsigned int texture, float u, float v, int curved);
+void vr_openvr_submit_menu(int curved);
 
 #ifdef __cplusplus
 }

--- a/d2/main/game.c
+++ b/d2/main/game.c
@@ -327,6 +327,8 @@ int set_screen_mode(int sm)
 	}
 
 	gr_set_current_canvas(NULL);
+	if (Screen_mode == SCREEN_MENU)
+		grd_curscreen->sc_mode = Game_screen_mode;
 
 	return 1;
 }


### PR DESCRIPTION
### Motivation

- Avoid rendering menus to the screen and then copying pixels into a VR texture, which is inefficient and error-prone. 
- Present menus directly on the VR curved/flat quad so UI appears correctly in stereoscopic VR. 
- Integrate menu rendering directly with the existing OpenVR submission pipeline to simplify the flip path.

### Description

- Added a dedicated menu render target (texture + FBO + depth buffer) and management to `vr_openvr.cpp` (`vr_menu_tex`, `vr_menu_fbo`, `vr_menu_depth`) and wired creation/teardown into the OpenVR GL init/release path. 
- Exposed new APIs in `vr_openvr.h` and implemented them: `vr_openvr_bind_menu`, `vr_openvr_unbind_menu`, and `vr_openvr_submit_menu` to bind the menu FBO and submit the menu texture to the VR compositor. 
- When a canvas is set to the OGL menu canvas in VR mode, `gr_set_current_canvas` (in `2d/canvas.c`) binds the menu FBO so menu drawing goes straight into the VR texture; it unbinds when leaving the OGL canvas. 
- Changed the OpenGL flip path in `arch/ogl/ogl.c` to call `vr_openvr_submit_menu` for non-game/non-movie screens in VR mode and made a small `set_screen_mode` adjustment in `main/game.c` to keep `grd_curscreen->sc_mode` consistent for menu mode.

### Testing

- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69589aab39488330853f01f9ef0ad7a4)