### PR TITLE
Adjust VR cockpit and HUD alignment

### DIFF
--- a/d2/include/vr_openvr.h
+++ b/d2/include/vr_openvr.h
@@ -19,6 +19,7 @@ void vr_openvr_adjust_eye_offset(float delta_meters);
 int vr_openvr_eye_projection(int eye, float *left, float *right, float *bottom, float *top);
 int vr_openvr_head_pose(vms_matrix *orient, vms_vector *position);
 int vr_openvr_current_eye(void);
+int vr_openvr_eye_center_offset(float *offset_x, float *offset_y);
 void vr_openvr_render_size(int *width, int *height);
 void vr_openvr_bind_eye(int eye);
 void vr_openvr_unbind_eye(void);

--- a/d2/main/vr_openvr.cpp
+++ b/d2/main/vr_openvr.cpp
@@ -527,6 +527,37 @@ int vr_openvr_current_eye(void)
 #endif
 }
 
+int vr_openvr_eye_center_offset(float *offset_x, float *offset_y)
+{
+#ifdef USE_OPENVR
+	if (!vr_openvr_active() || !vr_system || vr_current_eye < 0)
+		return 0;
+
+	float left = 0.0f;
+	float right = 0.0f;
+	float bottom = 0.0f;
+	float top = 0.0f;
+	if (!vr_openvr_eye_projection(vr_current_eye, &left, &right, &bottom, &top))
+		return 0;
+
+	const float width = right - left;
+	const float height = top - bottom;
+	const float offset = width != 0.0f ? -(right + left) / width : 0.0f;
+	const float offset_v = height != 0.0f ? -(top + bottom) / height : 0.0f;
+	if (offset_x)
+		*offset_x = offset;
+	if (offset_y)
+		*offset_y = offset_v;
+	return 1;
+#else
+	if (offset_x)
+		*offset_x = 0.0f;
+	if (offset_y)
+		*offset_y = 0.0f;
+	return 0;
+#endif
+}
+
 void vr_openvr_render_size(int *width, int *height)
 {
 #ifdef USE_OPENVR


### PR DESCRIPTION
### Motivation
- Enable stereoscopic VR mode to render the cockpit and HUD elements with independent X/Y scaling and a per-eye centering offset so gauges and text sit at the optical focus between eyes when `USE_OPENVR` is enabled.

### Description
- Added a new API `vr_openvr_eye_center_offset(float *offset_x, float *offset_y)` in `d2/include/vr_openvr.h` and implemented it in `d2/main/vr_openvr.cpp` to expose per-eye center offsets computed from the eye projection.
- Implemented OpenVR-aware HUD scaling and centering helpers in `d2/main/gauges.c` (`hud_vr_scale_x`, `hud_vr_scale_y`, `hud_vr_offset_x`, `hud_vr_offset_y`) and replaced the legacy `HUD_SCALE_X`/`HUD_SCALE_Y` macros with VR-aware variants so gauges use separate X/Y scale and offsets in stereoscopic mode.
- Added `cockpit_vr_adjust_rect` in `d2/main/gamerend.c` and applied it when rendering cockpit bitmaps (full cockpit, rear view, and status bar) so the bitmap position/size is adjusted per-eye before calling `ogl_ubitmapm_cs`.
- Guarded VR-specific code with `#ifdef USE_OPENVR` and included `vr_openvr.h` where needed.
- Modified files: `d2/include/vr_openvr.h`, `d2/main/vr_openvr.cpp`, `d2/main/gauges.c`, and `d2/main/gamerend.c`.

### Testing
- No automated tests were run on these changes in this rollout (no build or unit tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697820f7398c8330b83fe7b3b0d22aca)