### PR TITLE
Align VR HUD top elements and center status-bar numbers

### DIFF
--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -748,10 +748,20 @@ int get_pnum_for_hud()
 		return Player_num;
 }
 
+static inline int vr_hud_top_margin_y(void)
+{
+#ifdef USE_OPENVR
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
+		return grd_curcanv->cv_bitmap.bm_h / 10;
+#endif
+	return 0;
+}
+
 void hud_show_score()
 {
 	char	score_str[20];
 	int	w, h, aw;
+	int top_margin;
 
 	int pnum = get_pnum_for_hud();
 
@@ -767,6 +777,7 @@ void hud_show_score()
   	}
 
 	gr_get_string_size(score_str, &w, &h, &aw );
+	top_margin = vr_hud_top_margin_y();
 
 	if (Color_0_31_0 == -1)
 		Color_0_31_0 = BM_XRGB(0,31,0);
@@ -775,9 +786,9 @@ void hud_show_score()
     int offset_x = 0;
     int offset_y = 0;
 	cockpit_gauge_offset(&offset_x, &offset_y);
-	gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1) + offset_x, FSPACY(1) + offset_y, score_str);
+	gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1) + offset_x, FSPACY(1) + offset_y + top_margin, score_str);
 #else
-	gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1), FSPACY(1), score_str);
+	gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1), FSPACY(1) + top_margin, score_str);
 #endif
 }
 
@@ -818,6 +829,7 @@ void hud_show_score_added()
 	int	color;
 	int	w, h, aw;
 	char	score_str[20];
+	int top_margin;
 
 	if ( (Game_mode & GM_MULTI) && !((Game_mode & GM_MULTI_COOP) || (Game_mode & GM_MULTI_ROBOTS)) )
 		return;
@@ -826,6 +838,7 @@ void hud_show_score_added()
 		return;
 
 	gr_set_curfont( GAME_FONT );
+	top_margin = vr_hud_top_margin_y();
 
 	score_time -= FrameTime;
 	if (score_time > 0) {
@@ -843,7 +856,7 @@ void hud_show_score_added()
 
 		gr_get_string_size(score_str, &w, &h, &aw );
 		gr_set_fontcolor(BM_XRGB(0, color, 0),-1 );
-		gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1), LINE_SPACING+FSPACY(1), score_str);
+		gr_string(grd_curcanv->cv_bitmap.bm_w-w-FSPACX(1), LINE_SPACING+FSPACY(1) + top_margin, score_str);
 	} else {
 		score_time = 0;
 		score_display = 0;
@@ -889,17 +902,26 @@ void sb_show_score()
 
 	x = HUD_SCALE_X(SB_SCORE_RIGHT)-w-FSPACX(1);
 	y = HUD_SCALE_Y(SB_SCORE_Y);
+#ifdef USE_OPENVR
+	int draw_x = x + offset_x;
+	int draw_y = y + offset_y;
+	int draw_right = HUD_SCALE_X(SB_SCORE_RIGHT) + offset_x;
+#else
+	int draw_x = x;
+	int draw_y = y;
+	int draw_right = HUD_SCALE_X(SB_SCORE_RIGHT);
+#endif
 
 	//erase old score
 	gr_setcolor(BM_XRGB(0,0,0));
-	gr_rect(x,y,HUD_SCALE_X(SB_SCORE_RIGHT),y+LINE_SPACING);
+	gr_rect(draw_x, draw_y, draw_right, draw_y + LINE_SPACING);
 
 	if ( (Game_mode & GM_MULTI) && !((Game_mode & GM_MULTI_COOP) || (Game_mode & GM_MULTI_ROBOTS)) )
 		gr_set_fontcolor(BM_XRGB(0,20,0),-1 );
 	else
 		gr_set_fontcolor(BM_XRGB(0,31,0),-1 );
 
-	gr_string(x,y,score_str);
+	gr_string(draw_x, draw_y, score_str);
 }
 
 void sb_show_score_added()
@@ -933,22 +955,30 @@ void sb_show_score_added()
 		else
 			sprintf(score_str, "%5d", score_display);
 
-		gr_get_string_size(score_str, &w, &h, &aw );
-		x = HUD_SCALE_X(SB_SCORE_ADDED_RIGHT)-w-FSPACX(1);
-		gr_set_fontcolor(BM_XRGB(0, color, 0),-1 );
+	gr_get_string_size(score_str, &w, &h, &aw );
+	x = HUD_SCALE_X(SB_SCORE_ADDED_RIGHT)-w-FSPACX(1);
+	gr_set_fontcolor(BM_XRGB(0, color, 0),-1 );
 #ifdef USE_OPENVR
 	int offset_x = 0;
 	int offset_y = 0;
 
 	cockpit_gauge_offset(&offset_x, &offset_y);
-		gr_string(x + offset_x, HUD_SCALE_Y(SB_SCORE_ADDED_Y) + offset_y, score_str);
+	gr_string(x + offset_x, HUD_SCALE_Y(SB_SCORE_ADDED_Y) + offset_y, score_str);
 #else
-		gr_string(x, HUD_SCALE_Y(SB_SCORE_ADDED_Y), score_str);
+	gr_string(x, HUD_SCALE_Y(SB_SCORE_ADDED_Y), score_str);
 #endif
 	} else {
 		//erase old score
 		gr_setcolor(BM_XRGB(0,0,0));
+#ifdef USE_OPENVR
+		int offset_x = 0;
+		int offset_y = 0;
+
+		cockpit_gauge_offset(&offset_x, &offset_y);
+		gr_rect(x + offset_x, HUD_SCALE_Y(SB_SCORE_ADDED_Y) + offset_y, HUD_SCALE_X(SB_SCORE_ADDED_RIGHT) + offset_x, HUD_SCALE_Y(SB_SCORE_ADDED_Y) + offset_y + LINE_SPACING);
+#else
 		gr_rect(x,HUD_SCALE_Y(SB_SCORE_ADDED_Y),HUD_SCALE_X(SB_SCORE_ADDED_RIGHT),HUD_SCALE_Y(SB_SCORE_ADDED_Y)+LINE_SPACING);
+#endif
 		score_time = 0;
 		score_display = 0;
 	}
@@ -1676,6 +1706,7 @@ void hud_show_shield(void)
 void hud_show_lives()
 {
 	int x;
+	int top_margin;
 #ifdef USE_OPENVR
 	int offset_x = 0;
 	int offset_y = 0;
@@ -1687,6 +1718,8 @@ void hud_show_lives()
 	if (HUD_toolong)
 		return;
 
+	top_margin = vr_hud_top_margin_y();
+
 	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
 		x = HUD_SCALE_X(7);
 	else
@@ -1696,9 +1729,9 @@ void hud_show_lives()
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,31,0),-1 );
 #ifdef USE_OPENVR
-		gr_printf(x + offset_x, FSPACY(1) + offset_y, "%s: %d", TXT_DEATHS, Players[pnum].net_killed_total);
+		gr_printf(x + offset_x, FSPACY(1) + offset_y + top_margin, "%s: %d", TXT_DEATHS, Players[pnum].net_killed_total);
 #else
-		gr_printf(x, FSPACY(1), "%s: %d", TXT_DEATHS, Players[pnum].net_killed_total);
+		gr_printf(x, FSPACY(1) + top_margin, "%s: %d", TXT_DEATHS, Players[pnum].net_killed_total);
 #endif
 	}
 	else if (Players[pnum].lives > 1)  {
@@ -1707,11 +1740,11 @@ void hud_show_lives()
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,20,0),-1 );
 #ifdef USE_OPENVR
-		hud_bitblt_free(x,FSPACY(1) + offset_x,HUD_SCALE_X_AR(bm->bm_w) + offset_y,HUD_SCALE_Y_AR(bm->bm_h),bm);
-		gr_printf(HUD_SCALE_X_AR(bm->bm_w)+x + offset_x, FSPACY(1) + offset_y, " x %d", Players[pnum].lives-1);
+		hud_bitblt_free(x + offset_x, FSPACY(1) + offset_y + top_margin, HUD_SCALE_X_AR(bm->bm_w), HUD_SCALE_Y_AR(bm->bm_h), bm);
+		gr_printf(HUD_SCALE_X_AR(bm->bm_w)+x + offset_x, FSPACY(1) + offset_y + top_margin, " x %d", Players[pnum].lives-1);
 #else
-		hud_bitblt_free(x,FSPACY(1),HUD_SCALE_X_AR(bm->bm_w),HUD_SCALE_Y_AR(bm->bm_h),bm);
-		gr_printf(HUD_SCALE_X_AR(bm->bm_w)+x, FSPACY(1), " x %d", Players[pnum].lives-1);
+		hud_bitblt_free(x, FSPACY(1) + top_margin, HUD_SCALE_X_AR(bm->bm_w), HUD_SCALE_Y_AR(bm->bm_h), bm);
+		gr_printf(HUD_SCALE_X_AR(bm->bm_w)+x, FSPACY(1) + top_margin, " x %d", Players[pnum].lives-1);
 #endif
 	}
 
@@ -1756,7 +1789,11 @@ void sb_show_lives()
 		sprintf(killed_str, "%5d", Players[pnum].net_killed_total);
 		gr_get_string_size(killed_str, &w, &h, &aw);
 		gr_setcolor(BM_XRGB(0,0,0));
+#ifdef USE_OPENVR
+		gr_rect(last_x[HIRESMODE] + offset_x, HUD_SCALE_Y(y) + offset_y, HUD_SCALE_X(SB_SCORE_RIGHT) + offset_x, HUD_SCALE_Y(y) + offset_y + LINE_SPACING);
+#else
 		gr_rect(last_x[HIRESMODE], HUD_SCALE_Y(y), HUD_SCALE_X(SB_SCORE_RIGHT), HUD_SCALE_Y(y)+LINE_SPACING);
+#endif
 		gr_set_fontcolor(BM_XRGB(0,20,0),-1);
 		x = HUD_SCALE_X(SB_SCORE_RIGHT)-w-FSPACX(1);
 #ifdef USE_OPENVR
@@ -1770,16 +1807,21 @@ void sb_show_lives()
 
 	//erase old icons
 	gr_setcolor(BM_XRGB(0,0,0));
+#ifdef USE_OPENVR
+	gr_rect(HUD_SCALE_X(x) + offset_x, HUD_SCALE_Y(y) + offset_y, HUD_SCALE_X(SB_SCORE_RIGHT) + offset_x, HUD_SCALE_Y(y + bm->bm_h) + offset_y);
+#else
 	gr_rect(HUD_SCALE_X(x), HUD_SCALE_Y(y), HUD_SCALE_X(SB_SCORE_RIGHT), HUD_SCALE_Y(y+bm->bm_h));
+#endif
 
 	if (Players[pnum].lives-1 > 0) {
 		gr_set_curfont( GAME_FONT );
 		gr_set_fontcolor(BM_XRGB(0,20,0),-1 );
 		PAGE_IN_GAUGE( GAUGE_LIVES );
-		hud_bitblt_free(HUD_SCALE_X(x),HUD_SCALE_Y(y),HUD_SCALE_X_AR(bm->bm_w),HUD_SCALE_Y_AR(bm->bm_h),bm);
 #ifdef USE_OPENVR
+		hud_bitblt_free(HUD_SCALE_X(x) + offset_x, HUD_SCALE_Y(y) + offset_y, HUD_SCALE_X_AR(bm->bm_w), HUD_SCALE_Y_AR(bm->bm_h), bm);
 		gr_printf(HUD_SCALE_X(x)+HUD_SCALE_X_AR(bm->bm_w) + offset_x, HUD_SCALE_Y(y) + offset_y, " x %d", Players[pnum].lives-1);
 #else
+		hud_bitblt_free(HUD_SCALE_X(x),HUD_SCALE_Y(y),HUD_SCALE_X_AR(bm->bm_w),HUD_SCALE_Y_AR(bm->bm_h),bm);
 		gr_printf(HUD_SCALE_X(x)+HUD_SCALE_X_AR(bm->bm_w), HUD_SCALE_Y(y), " x %d", Players[pnum].lives-1);
 #endif
 	}
@@ -2646,6 +2688,7 @@ void sb_draw_energy_bar(int energy)
 {
 	int erase_height;
 	int ew, eh, eaw;
+	int energy_x;
 
 	PAGE_IN_GAUGE( SB_GAUGE_ENERGY );
 #ifdef USE_OPENVR
@@ -2662,16 +2705,21 @@ void sb_draw_energy_bar(int energy)
 	erase_height = HUD_SCALE_Y((100 - energy) * SB_ENERGY_GAUGE_H / 100);
 	if (erase_height > 0) {
 		gr_setcolor(0);
+#ifdef USE_OPENVR
+		gr_urect(HUD_SCALE_X(SB_ENERGY_GAUGE_X) + offset_x, HUD_SCALE_Y(SB_ENERGY_GAUGE_Y) + offset_y, HUD_SCALE_X(SB_ENERGY_GAUGE_X) + HUD_SCALE_X(SB_ENERGY_GAUGE_W) - 1 + offset_x, HUD_SCALE_Y(SB_ENERGY_GAUGE_Y) + erase_height - 1 + offset_y);
+#else
 		gr_urect(HUD_SCALE_X(SB_ENERGY_GAUGE_X), HUD_SCALE_Y(SB_ENERGY_GAUGE_Y), HUD_SCALE_X(SB_ENERGY_GAUGE_X) + HUD_SCALE_X(SB_ENERGY_GAUGE_W) - 1, HUD_SCALE_Y(SB_ENERGY_GAUGE_Y) + erase_height - 1);
+#endif
 	}
 
 	//draw numbers
 	gr_set_fontcolor(BM_XRGB(25,18,6),-1 );
 	gr_get_string_size((energy>199)?"200":(energy>99)?"100":(energy>9)?"00":"0",&ew,&eh,&eaw);
+	energy_x = HUD_SCALE_X(SB_ENERGY_GAUGE_X) + (HUD_SCALE_X(SB_ENERGY_GAUGE_W) - ew) / 2;
 #ifdef USE_OPENVR
-	gr_printf((grd_curscreen->sc_w/3)-(ew/2) + offset_x,HUD_SCALE_Y(SB_ENERGY_GAUGE_Y + SB_ENERGY_GAUGE_H - GAME_FONT->ft_h - (GAME_FONT->ft_h / 4)) + offset_y,"%d",energy);
+	gr_printf(energy_x + offset_x, HUD_SCALE_Y(SB_ENERGY_GAUGE_Y + SB_ENERGY_GAUGE_H - GAME_FONT->ft_h - (GAME_FONT->ft_h / 4)) + offset_y, "%d", energy);
 #else
-	gr_printf((grd_curscreen->sc_w/3)-(ew/2),HUD_SCALE_Y(SB_ENERGY_GAUGE_Y + SB_ENERGY_GAUGE_H - GAME_FONT->ft_h - (GAME_FONT->ft_h / 4)),"%d",energy);
+	gr_printf(energy_x, HUD_SCALE_Y(SB_ENERGY_GAUGE_Y + SB_ENERGY_GAUGE_H - GAME_FONT->ft_h - (GAME_FONT->ft_h / 4)), "%d", energy);
 #endif
 	gr_set_current_canvas(NULL);
 }
@@ -2695,7 +2743,11 @@ void sb_draw_afterburner()
 	erase_height = HUD_SCALE_Y(fixmul((f1_0 - Players[pnum].afterburner_charge),SB_AFTERBURNER_GAUGE_H-1));
 	gr_setcolor( 0 );
 	for (i=0;i<erase_height;i++)
+#ifdef USE_OPENVR
+		gr_uline( i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X-1) + offset_x), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y) + i + offset_y), i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X+(SB_AFTERBURNER_GAUGE_W)) + offset_x), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y) + i + offset_y) );
+#else
 		gr_uline( i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X-1)), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y)+i), i2f(HUD_SCALE_X(SB_AFTERBURNER_GAUGE_X+(SB_AFTERBURNER_GAUGE_W))), i2f(HUD_SCALE_Y(SB_AFTERBURNER_GAUGE_Y)+i) );
+#endif
 	//draw legend
 	if (Players[pnum].flags & PLAYER_FLAGS_AFTERBURNER)
 		gr_set_fontcolor(BM_XRGB(45,0,0),-1 );
@@ -2715,6 +2767,8 @@ void sb_draw_shield_num(int shield)
 {
 	//draw numbers
 	int sw, sh, saw;
+	int bm_num = shield >= 100 ? 9 : (shield / 10);
+	int shield_x;
 #ifdef USE_OPENVR
 	int offset_x = 0;
 	int offset_y = 0;
@@ -2725,10 +2779,12 @@ void sb_draw_shield_num(int shield)
 	gr_set_fontcolor(BM_XRGB(14,14,23),-1 );
 
 	gr_get_string_size((shield>199)?"200":(shield>99)?"100":(shield>9)?"00":"0",&sw,&sh,&saw);
+	PAGE_IN_GAUGE( GAUGE_SHIELDS+9-bm_num );
+	shield_x = HUD_SCALE_X(SB_SHIELD_GAUGE_X) + (HUD_SCALE_X(GameBitmaps[GET_GAUGE_INDEX(GAUGE_SHIELDS+9-bm_num)].bm_w) - sw) / 2;
 #ifdef USE_OPENVR
-	gr_printf((grd_curscreen->sc_w/2.266)-(sw/2) + offset_x, HUD_SCALE_Y(SB_SHIELD_NUM_Y) + offset_y, "%d", shield);
+	gr_printf(shield_x + offset_x, HUD_SCALE_Y(SB_SHIELD_NUM_Y) + offset_y, "%d", shield);
 #else
-	gr_printf((grd_curscreen->sc_w/2.266)-(sw/2), HUD_SCALE_Y(SB_SHIELD_NUM_Y), "%d", shield);
+	gr_printf(shield_x, HUD_SCALE_Y(SB_SHIELD_NUM_Y), "%d", shield);
 #endif
 }
 

--- a/d2/main/hud.c
+++ b/d2/main/hud.c
@@ -46,6 +46,15 @@ int HUD_toolong = 0;
 static int HUD_color = -1;
 static int HUD_init_message_literal_worth_showing(int class_flag, const char *message);
 
+static inline int vr_hud_top_margin_y(void)
+{
+#ifdef USE_OPENVR
+	if (PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT)
+		return grd_curcanv->cv_bitmap.bm_h / 10;
+#endif
+	return 0;
+}
+
 void HUD_clear_messages()
 {
 	HUD_nmessages = 0;
@@ -60,6 +69,7 @@ void HUD_clear_messages()
 void HUD_render_message_frame()
 {
 	int i,j,y;
+	int top_margin;
 
 	HUD_toolong = 0;
 
@@ -94,11 +104,12 @@ void HUD_render_message_frame()
 			HUD_color = BM_XRGB(0,28,0);
 
 		gr_set_curfont( GAME_FONT );
+		top_margin = vr_hud_top_margin_y();
 
 		if (is_observer())
-			y = Observer_message_y_start;
+			y = Observer_message_y_start + top_margin;
 		else
-			y = FSPACY(1);
+			y = FSPACY(1) + top_margin;
 
 		if (Guided_missile[Player_num] && Guided_missile[Player_num]->type==OBJ_WEAPON && Guided_missile[Player_num]->id==GUIDEDMISS_ID &&
 		Guided_missile[Player_num]->signature==Guided_missile_sig[Player_num] && PlayerCfg.GuidedInBigWindow)


### PR DESCRIPTION
### Motivation
- Prevent HUD elements from being visually clipped or misaligned in VR cockpit view by adding a small top margin and applying per-eye cockpit offsets to top HUD elements. 
- Fix stereo inconsistencies for the lives icon and counts so icons and text line up per eye in cockpit mode. 
- Keep numeric labels centered on their status-bar gauges (energy and shield) so the digits remain visually centered when VR offsets are applied. 

### Description
- Added a helper `vr_hud_top_margin_y()` (in `d2/main/gauges.c` and `d2/main/hud.c`) that returns a cockpit top margin when `USE_OPENVR` and `PlayerCfg.CurrentCockpitMode == CM_FULL_COCKPIT`. 
- Applied the top margin to `hud_show_score`, `hud_show_score_added`, `hud_show_lives`, and HUD message rendering in `HUD_render_message_frame()` so top HUD strings are shifted downward in VR cockpit view. 
- Corrected life icon and count drawing to include both the OpenVR `cockpit_gauge_offset` and the new top margin so the blit/erase/print positions match per eye. 
- Centered status-bar energy and shield digits by computing `energy_x` and `shield_x` from gauge dimensions and bitmap sizes and using those coordinates (with VR offsets when enabled). 
- Improved `sb_show_score` erase/draw to use computed per-eye `draw_x/draw_y/draw_right` so clearing and drawing use identical coordinates under `USE_OPENVR`. 

### Testing
- No automated tests were run for these changes. 
- Changes are limited to `d2/main/gauges.c` and `d2/main/hud.c` and should be validated with manual runtime checks in VR cockpit mode to confirm that top-edge cropping, stereo misalignment, and numeric centering are resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2c6094348330b4f5b025278e0275)