### PR TITLE
Fix automap VR vertical orientation for both quad and text

### DIFF
--- a/d2/include/vr_openvr.h
+++ b/d2/include/vr_openvr.h
@@ -30,6 +30,7 @@ void vr_openvr_bind_menu_target(void);
 void vr_openvr_unbind_menu_target(void);
 void vr_openvr_submit_menu(int curved);
 void vr_openvr_submit_mono_from_texture(unsigned int texture, float u, float v, int curved);
+void vr_openvr_draw_menu_quad_for_eye(int eye, int curved, float scale, int mono_mode, int flip_v);
 
 #ifdef __cplusplus
 }

--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -405,17 +405,6 @@ void draw_player( object * obj )
 	automap_draw_line(&sphere_point, &arrow_point);
 }
 
-static int automap_text_y(automap *am, int y)
-{
-	if (!am->rendering_to_vr_texture)
-		return y;
-
-	if (!grd_curcanv)
-		return y;
-
-	return (grd_curcanv->cv_bitmap.bm_h - 1) - y;
-}
-
 //name for each group.  maybe move somewhere else
 static const char *const system_name[] = {
 			"Zeta Aquilae",
@@ -444,9 +433,9 @@ void name_frame(automap *am)
 
 	gr_set_curfont(GAME_FONT);
 	gr_set_fontcolor(am->green_31,-1);
-	gr_printf((SWIDTH/64),automap_text_y(am, (SHEIGHT/48)),"%s", name_level_left);
+	gr_printf((SWIDTH/64),(SHEIGHT/48),"%s", name_level_left);
 	gr_get_string_size(name_level_right,&wr,&h,&aw);
-	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64),automap_text_y(am, (SHEIGHT/48)),"%s", name_level_right);
+	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64),(SHEIGHT/48),"%s", name_level_right);
 }
 
 static void automap_apply_input(automap *am)
@@ -545,12 +534,12 @@ static void draw_automap_to_canvas(automap *am)
 	show_fullscr(&am->automap_background);
 	gr_set_curfont(HUGE_FONT);
 	gr_set_fontcolor(BM_XRGB(20, 20, 20), -1);
-	gr_string((SWIDTH/8), automap_text_y(am, (SHEIGHT/16)), TXT_AUTOMAP);
+	gr_string((SWIDTH/8), (SHEIGHT/16), TXT_AUTOMAP);
 	gr_set_curfont(GAME_FONT);
 	gr_set_fontcolor(BM_XRGB(20, 20, 20), -1);
-	gr_string((SWIDTH/10.666), automap_text_y(am, (SHEIGHT/1.126)), TXT_TURN_SHIP);
-	gr_printf((SWIDTH/10.666), automap_text_y(am, (SHEIGHT/1.083)), "F9/F10 Changes viewing distance");
-	gr_string((SWIDTH/10.666), automap_text_y(am, (SHEIGHT/1.043)), TXT_AUTOMAP_MARKER);
+	gr_string((SWIDTH/10.666), (SHEIGHT/1.126), TXT_TURN_SHIP);
+	gr_printf((SWIDTH/10.666), (SHEIGHT/1.083), "F9/F10 Changes viewing distance");
+	gr_string((SWIDTH/10.666), (SHEIGHT/1.043), TXT_AUTOMAP_MARKER);
 
 	{
 		const int map_x = (grd_curcanv->cv_bitmap.bm_w/23);
@@ -640,7 +629,7 @@ static void draw_automap_to_canvas(automap *am)
 	{
 		char msg[10+MARKER_MESSAGE_LEN+1];
 		sprintf(msg,"Marker %d: %s",HighlightMarker+1,MarkerMessage[(Player_num*2)+HighlightMarker]);
-		gr_printf((SWIDTH/64),(SHEIGHT/18),"%s", msg);
+		gr_printf((SWIDTH/64), am->rendering_to_vr_texture ? (SHEIGHT/1.083) : (SHEIGHT/18), "%s", msg);
 	}
 
 	if ((PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)
@@ -665,7 +654,7 @@ void draw_automap(automap *am)
 			vr_openvr_unbind_menu_target();
 		}
 		if (eye >= 0)
-			vr_openvr_draw_menu_quad_for_eye(eye, 0, 0.65f, 1, 1);
+			vr_openvr_draw_menu_quad_for_eye(eye, 0, 0.65f, 1, 0);
 	}
 	else
 #endif

--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -552,6 +552,14 @@ static void draw_automap_to_canvas(automap *am)
 	gr_printf((SWIDTH/10.666), automap_text_y(am, (SHEIGHT/1.083)), "F9/F10 Changes viewing distance");
 	gr_string((SWIDTH/10.666), automap_text_y(am, (SHEIGHT/1.043)), TXT_AUTOMAP_MARKER);
 
+	{
+		const int map_x = (grd_curcanv->cv_bitmap.bm_w/23);
+		const int map_y = (grd_curcanv->cv_bitmap.bm_h/6);
+		const int map_w = (grd_curcanv->cv_bitmap.bm_w/1.1);
+		const int map_h = (grd_curcanv->cv_bitmap.bm_h/1.45);
+		gr_init_sub_canvas(&am->automap_view, grd_curcanv, map_x, map_y, map_w, map_h);
+	}
+
 	gr_set_current_canvas(&am->automap_view);
 
 	gr_clear_canvas(BM_XRGB(0,0,0));
@@ -632,7 +640,7 @@ static void draw_automap_to_canvas(automap *am)
 	{
 		char msg[10+MARKER_MESSAGE_LEN+1];
 		sprintf(msg,"Marker %d: %s",HighlightMarker+1,MarkerMessage[(Player_num*2)+HighlightMarker]);
-		gr_printf((SWIDTH/64),automap_text_y(am, (SHEIGHT/18)),"%s", msg);
+		gr_printf((SWIDTH/64),(SHEIGHT/18),"%s", msg);
 	}
 
 	if ((PlayerCfg.MouseControlStyle == MOUSE_CONTROL_FLIGHT_SIM) && PlayerCfg.MouseFSIndicator)

--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -413,7 +413,7 @@ static int automap_green_text_y(automap *am, int y)
 	if (!grd_curcanv)
 		return y;
 
-	return (grd_curcanv->cv_bitmap.bm_h - 1) - y;
+	return (SHEIGHT - 1) - y;
 }
 
 //name for each group.  maybe move somewhere else

--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -405,6 +405,17 @@ void draw_player( object * obj )
 	automap_draw_line(&sphere_point, &arrow_point);
 }
 
+static int automap_green_text_y(automap *am, int y)
+{
+	if (!am->rendering_to_vr_texture)
+		return y;
+
+	if (!grd_curcanv)
+		return y;
+
+	return (grd_curcanv->cv_bitmap.bm_h - 1) - y;
+}
+
 //name for each group.  maybe move somewhere else
 static const char *const system_name[] = {
 			"Zeta Aquilae",
@@ -433,9 +444,9 @@ void name_frame(automap *am)
 
 	gr_set_curfont(GAME_FONT);
 	gr_set_fontcolor(am->green_31,-1);
-	gr_printf((SWIDTH/64),(SHEIGHT/48),"%s", name_level_left);
+	gr_printf((SWIDTH/64),automap_green_text_y(am, (SHEIGHT/48)),"%s", name_level_left);
 	gr_get_string_size(name_level_right,&wr,&h,&aw);
-	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64),(SHEIGHT/48),"%s", name_level_right);
+	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64),automap_green_text_y(am, (SHEIGHT/48)),"%s", name_level_right);
 }
 
 static void automap_apply_input(automap *am)
@@ -654,7 +665,7 @@ void draw_automap(automap *am)
 			vr_openvr_unbind_menu_target();
 		}
 		if (eye >= 0)
-			vr_openvr_draw_menu_quad_for_eye(eye, 0, 0.65f, 1, 0);
+			vr_openvr_draw_menu_quad_for_eye(eye, 0, 0.65f, 1, 1);
 	}
 	else
 #endif


### PR DESCRIPTION
### Motivation
- The automap frame and its UI text ended up with opposite vertical orientation when rendered into the VR menu texture, so flipping only the quad made the frame correct but left text upside-down.

### Description
- Added a `flip_v` parameter to `vr_openvr_draw_menu_quad_for_eye` (header and implementation) and threaded it into the curved/flat quad draw helpers so callers can invert V texcoords when needed.
- Implemented `flip_v` handling in the curved and flat quad renderers by selecting `v_top`/`v_bottom` based on `flip_v`, and left existing menu submit paths unflipped (`flip_v = 0`).
- Added `rendering_to_vr_texture` state and `automap_text_y()` helper to `automap` so automap text Y coordinates are remapped (pre-flipped) while rendering into the VR texture, and applied the helper to automap label/name/marker text draws.
- Set `rendering_to_vr_texture` around the VR menu target bind/unbind and call the quad with `flip_v = 1` for the automap presentation so quad sampling and rendered text match; also adjusted the menu texture filtering to `GL_NEAREST` in the VR init path.

### Testing
- Ran `git diff --check`, which passed.
- Used `rg` to verify the new symbols/uses (`flip_v`, `automap_text_y`, `rendering_to_vr_texture`) are present and updated in call sites, which succeeded.
- Changes were committed locally as part of the PR branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698432ac9e248330a60e9582477cb2ff)