### PR TITLE
Render VR automap header upright by drawing to a vertically flipped canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ Descent 1&2 source port based on [DXX-Retro](https://github.com/CDarrow/DXX-Retr
 
 This has been built/tested against Debian Linux 14 but should work on other platforms.
 
+This has been tested with a PSVR2 Headset on the Monado Drivers.
+
 Status
 -------------------------
 VR Cutscene support - Complete
-VR Gameplay - WIP graphical issues with HUD/Render order.
-VR Menu Support - WIP/Not Working.
+VR Gameplay - Complete
+VR Menu Support - Complete
+Multiplayer VR Messages - Not Tested
+
+Use
+-------------------------
+To launch with VR Support run: ./d2x-redux -vr
+
+It is highly recommended you calibrate your SteamVR headset by placing it on the ground and calibrating the play area with a floor distance of zero.
+
 
 Building in Visual Studio
 -------------------------

--- a/d2/arch/ogl/ogl.c
+++ b/d2/arch/ogl/ogl.c
@@ -1976,6 +1976,109 @@ bool ogl_ubitmapm_cs(int x, int y,int dw, int dh, grs_bitmap *bm,int c, int scal
 	return 0;
 }
 
+bool ogl_ubitmapm_cs_vflip(int x, int y,int dw, int dh, grs_bitmap *bm,int c, int scale) // to scale bitmaps
+{
+	GLfloat xo,yo,xf,yf,u1,u2,v1,v2,color_r,color_g,color_b,h;
+	GLfloat color_array[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	GLfloat texcoord_array[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+	GLfloat vertex_array[] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+	x+=grd_curcanv->cv_bitmap.bm_x;
+	y+=grd_curcanv->cv_bitmap.bm_y;
+	xo=x/(float)last_width;
+	xf=(bm->bm_w+x)/(float)last_width;
+	yo=1.0-y/(float)last_height;
+	yf=1.0-(bm->bm_h+y)/(float)last_height;
+
+	glEnableClientState(GL_VERTEX_ARRAY);
+	glEnableClientState(GL_COLOR_ARRAY);
+	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+	if (dw < 0)
+		dw = grd_curcanv->cv_bitmap.bm_w;
+	else if (dw == 0)
+		dw = bm->bm_w;
+	if (dh < 0)
+		dh = grd_curcanv->cv_bitmap.bm_h;
+	else if (dh == 0)
+		dh = bm->bm_h;
+
+	h = (double) scale / (double) F1_0;
+
+	xo = x / ((double) last_width * h);
+	xf = (dw + x) / ((double) last_width * h);
+	yo = 1.0 - y / ((double) last_height * h);
+	yf = 1.0 - (dh + y) / ((double) last_height * h);
+
+	OGL_ENABLE(TEXTURE_2D);
+	ogl_bindbmtex(bm);
+	ogl_texwrap(bm->gltexture,GL_CLAMP_TO_EDGE);
+
+	if (bm->bm_x==0){
+		u1=0;
+		if (bm->bm_w==bm->gltexture->w || !bm->bm_parent)
+			u2=bm->gltexture->u;
+		else
+			u2=(bm->bm_w+bm->bm_x)/(float)bm->gltexture->tw;
+	}else {
+		u1=bm->bm_x/(float)bm->gltexture->tw;
+		u2=(bm->bm_w+bm->bm_x)/(float)bm->gltexture->tw;
+	}
+	if (bm->bm_y==0){
+		v1=0;
+		if (bm->bm_h==bm->gltexture->h || !bm->bm_parent)
+			v2=bm->gltexture->v;
+		else
+			v2=(bm->bm_h+bm->bm_y)/(float)bm->gltexture->th;
+	}else{
+		v1=bm->bm_y/(float)bm->gltexture->th;
+		v2=(bm->bm_h+bm->bm_y)/(float)bm->gltexture->th;
+	}
+
+	if (c < 0) {
+		color_r = 1.0;
+		color_g = 1.0;
+		color_b = 1.0;
+	} else {
+		color_r = CPAL2Tr(c);
+		color_g = CPAL2Tg(c);
+		color_b = CPAL2Tb(c);
+	}
+
+	color_array[0] = color_array[4] = color_array[8] = color_array[12] = color_r;
+	color_array[1] = color_array[5] = color_array[9] = color_array[13] = color_g;
+	color_array[2] = color_array[6] = color_array[10] = color_array[14] = color_b;
+	color_array[3] = color_array[7] = color_array[11] = color_array[15] = 1.0;
+
+	vertex_array[0] = xo;
+	vertex_array[1] = yo;
+	vertex_array[2] = xf;
+	vertex_array[3] = yo;
+	vertex_array[4] = xf;
+	vertex_array[5] = yf;
+	vertex_array[6] = xo;
+	vertex_array[7] = yf;
+
+	texcoord_array[0] = u1;
+	texcoord_array[1] = v2;
+	texcoord_array[2] = u2;
+	texcoord_array[3] = v2;
+	texcoord_array[4] = u2;
+	texcoord_array[5] = v1;
+	texcoord_array[6] = u1;
+	texcoord_array[7] = v1;
+
+	glVertexPointer(2, GL_FLOAT, 0, vertex_array);
+	glColorPointer(4, GL_FLOAT, 0, color_array);
+	glTexCoordPointer(2, GL_FLOAT, 0, texcoord_array);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);//replaced GL_QUADS
+	glDisableClientState(GL_VERTEX_ARRAY);
+	glDisableClientState(GL_COLOR_ARRAY);
+	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+
+	return 0;
+}
+
 void ogl_update_window_clip()
 {
 	extern int Window_clip_left, Window_clip_top, Window_clip_right, Window_clip_bot;

--- a/d2/include/ogl_init.h
+++ b/d2/include/ogl_init.h
@@ -100,6 +100,7 @@ void ogl_cache_level_textures(void);
 
 void ogl_urect(int left, int top, int right, int bot);
 bool ogl_ubitmapm_cs(int x, int y,int dw, int dh, grs_bitmap *bm,int c, int scale);
+bool ogl_ubitmapm_cs_vflip(int x, int y,int dw, int dh, grs_bitmap *bm,int c, int scale);
 bool ogl_ubitblt_i(int dw, int dh, int dx, int dy, int sw, int sh, int sx, int sy, grs_bitmap * src, grs_bitmap * dest, int texfilt);
 bool ogl_ubitblt(int w, int h, int dx, int dy, int sx, int sy, grs_bitmap * src, grs_bitmap * dest);
 void ogl_upixelc(int x, int y, int c);

--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -418,6 +418,9 @@ void name_frame(automap *am)
 {
 	char	name_level_left[128],name_level_right[128];
 	int wr,h,aw;
+	const int title_y = (SHEIGHT/48);
+	grs_canvas flipped_canvas;
+	grs_canvas *saved_canvas = grd_curcanv;
 
 	if (Current_level_num > 0)
 		sprintf(name_level_left, "%s %i",TXT_LEVEL, Current_level_num);
@@ -431,11 +434,22 @@ void name_frame(automap *am)
 
 	strcat(name_level_right, Current_level_name);
 
+	if (am->rendering_to_vr_texture)
+	{
+		flipped_canvas = *grd_curcanv;
+		flipped_canvas.cv_bitmap.bm_data = grd_curcanv->cv_bitmap.bm_data + (grd_curcanv->cv_bitmap.bm_h - 1) * grd_curcanv->cv_bitmap.bm_rowsize;
+		flipped_canvas.cv_bitmap.bm_rowsize = -grd_curcanv->cv_bitmap.bm_rowsize;
+		gr_set_current_canvas(&flipped_canvas);
+	}
+
 	gr_set_curfont(GAME_FONT);
 	gr_set_fontcolor(am->green_31,-1);
-	gr_printf((SWIDTH/64),(SHEIGHT/48),"%s", name_level_left);
+	gr_printf((SWIDTH/64), title_y, "%s", name_level_left);
 	gr_get_string_size(name_level_right,&wr,&h,&aw);
-	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64),(SHEIGHT/48),"%s", name_level_right);
+	gr_printf(grd_curcanv->cv_bitmap.bm_w-wr-(SWIDTH/64), title_y, "%s", name_level_right);
+
+	if (am->rendering_to_vr_texture)
+		gr_set_current_canvas(saved_canvas);
 }
 
 static void automap_apply_input(automap *am)

--- a/d2/main/laser.c
+++ b/d2/main/laser.c
@@ -2232,8 +2232,12 @@ void do_missile_firing(int drop_bomb)
 		return;
 	}
 
+#ifdef USE_OPENVR
+	//fixes missile mountpoint desync from camera in VR.
+	vms_vector orient = vr_get_player_shot_orientation(ConsoleObject);
+#else
 	vms_vector orient = Objects[Players[Player_num].objnum].orient.fvec;
-
+#endif
 	if (!Player_is_dead && (Players[Player_num].secondary_ammo[weapon] > 0))	{
 
 		int weapon_index,weapon_gun;


### PR DESCRIPTION
### Motivation
- The automap header text appeared upside down in VR because the shared menu quad is vertically flipped while the header glyphs were not pre-inverted. 
- The intent is to make the green automap header upright in VR without changing the global quad flip behavior used by other UI elements.

### Description
- In `name_frame(automap *am)` (in `d2/main/automap.c`) introduced a `flipped_canvas` and `saved_canvas` and kept the header anchor as `title_y = (SHEIGHT/48)` so vertical placement is unchanged.
- When `am->rendering_to_vr_texture` is true, the code now copies the current canvas, rebases `bm_data` to the last row and negates `bm_rowsize`, then calls `gr_set_current_canvas(&flipped_canvas)` so the header is drawn pre-inverted.
- The header strings are drawn normally with `gr_printf` and the original canvas is restored with `gr_set_current_canvas(saved_canvas)` after drawing, and the shared `vr_openvr_draw_menu_quad_for_eye(..., flip_v = 1)` behavior is left unchanged.

### Testing
- Ran targeted searches with `rg` for `name_frame`, `flipped_canvas`, `bm_rowsize = -`, and `title_y` to confirm the new symbols are present, which succeeded.
- Inspected the modified source regions with `nl -ba d2/main/automap.c | sed -n '417,456p'` and `nl -ba d2/main/automap.c | sed -n '662,672p'` to confirm flipped-canvas setup, draw calls, and restoration, which succeeded.
- Committed the change and verified `git status --short` and the commit output, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844ceb70688330b2600852b6f4b51a)