### PR TITLE
Define and maintain global SDL window dimensions in OGL backend

### DIFF
--- a/d1/arch/ogl/gr.c
+++ b/d1/arch/ogl/gr.c
@@ -87,6 +87,7 @@
 
 #ifdef OGLES
 int sdl_video_flags = 0;
+int sdl_window_width = 0, sdl_window_height = 0;
 
 #ifdef RPI
 static EGL_DISPMANX_WINDOW_T nativewindow;
@@ -97,10 +98,12 @@ static DISPMANX_DISPLAY_HANDLE_T dispman_display=DISPMANX_NO_HANDLE;
 #else
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 int sdl_video_flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
+int sdl_window_width = 0, sdl_window_height = 0;
 static SDL_Window *sdl_window = NULL;
 static SDL_GLContext sdl_gl_context = NULL;
 #else
 int sdl_video_flags = SDL_OPENGL;
+int sdl_window_width = 0, sdl_window_height = 0;
 #endif
 #endif
 int gr_installed = 0;
@@ -359,6 +362,8 @@ int ogl_init_window(int x, int y)
 	}
 
 	if (!sdl_window) {
+		sdl_window_width = use_x;
+		sdl_window_height = use_y;
 		sdl_window = SDL_CreateWindow(DESCENT_VERSION, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, use_x, use_y, use_flags);
 		if (!sdl_window)
 			Error("Could not create SDL window: %s\n", SDL_GetError());
@@ -368,6 +373,8 @@ int ogl_init_window(int x, int y)
 			SDL_FreeSurface(icon);
 		}
 	} else {
+		sdl_window_width = use_x;
+		sdl_window_height = use_y;
 		SDL_SetWindowSize(sdl_window, use_x, use_y);
 		SDL_SetWindowFullscreen(sdl_window, (use_flags & SDL_WINDOW_FULLSCREEN) ? SDL_WINDOW_FULLSCREEN : 0);
 		SDL_SetWindowBordered(sdl_window, (use_flags & SDL_WINDOW_BORDERLESS) ? SDL_FALSE : SDL_TRUE);
@@ -407,6 +414,8 @@ int ogl_init_window(int x, int y)
 		Error("Could not set %dx%dx%d opengl video mode: %s\n", x, y, GameArg.DbgBpp, SDL_GetError());
 #endif
 	}
+	sdl_window_width = use_x;
+	sdl_window_height = use_y;
 #endif
 
 #ifdef OGLES
@@ -535,7 +544,10 @@ int gr_toggle_fullscreen(void)
 	{
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 		if (sdl_window)
+		{
 			SDL_SetWindowFullscreen(sdl_window, (sdl_video_flags & SDL_WINDOW_FULLSCREEN) ? SDL_WINDOW_FULLSCREEN : 0);
+			SDL_GetWindowSize(sdl_window, &sdl_window_width, &sdl_window_height);
+		}
 #else
 		if (sdl_no_modeswitch == 0) {
 			if (!SDL_VideoModeOK(SM_W(Game_screen_mode), SM_H(Game_screen_mode), GameArg.DbgBpp, sdl_video_flags))
@@ -547,6 +559,8 @@ int gr_toggle_fullscreen(void)
 			{
 				Error("Could not set %dx%dx%d opengl video mode: %s\n", SM_W(Game_screen_mode), SM_H(Game_screen_mode), GameArg.DbgBpp, SDL_GetError());
 			}
+			sdl_window_width = SM_W(Game_screen_mode);
+			sdl_window_height = SM_H(Game_screen_mode);
 		}
 #endif
 #ifdef RPI


### PR DESCRIPTION
### Motivation
- The VR/OpenVR code expects `extern int sdl_window_width, sdl_window_height;` to be defined and linker-visible so window dimensions can be read from `vr_openvr.cpp` during rendering setup.
- Keep the runtime copy of the SDL window size in sync with all code paths that create, resize, or toggle fullscreen so consumers see the current resolution.

### Description
- Added non-static globals `int sdl_window_width, sdl_window_height;` in `d1/arch/ogl/gr.c` alongside existing SDL/OpenGL globals so the symbols are visible to the linker.
- In SDL2 window initialization (`ogl_init_window`) assign `sdl_window_width = use_x; sdl_window_height = use_y;` before calling `SDL_CreateWindow` and also before `SDL_SetWindowSize` so the globals reflect the requested size.
- After fullscreen toggles on SDL2 (`gr_toggle_fullscreen`) refresh the globals with the actual window size using `SDL_GetWindowSize` when the window exists.
- In SDL1 paths update the globals after `SDL_SetVideoMode` and when changing modes from `Game_screen_mode` so legacy code paths also keep dimensions current.

### Testing
- Applied the patch to `d1/arch/ogl/gr.c` and verified the modified regions by inspecting the file contents.
- Ran `git diff --check` which produced no whitespace/style errors and succeeded.
- Ran `git status --short` to confirm the patch is present and the working tree shows the updated file (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69856da7f39c833081df8c0fd276195a)