### PR TITLE
d1: use active VR eye offset when rendering gameplay frames

### DIFF
--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -51,6 +51,9 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "mission.h"
 #include "gameseq.h"
 #include "args.h"
+#ifdef USE_OPENVR
+#include "vr_openvr.h"
+#endif
 
 #ifdef OGL
 #include "ogl_init.h"
@@ -466,9 +469,22 @@ void update_cockpits();
 //render a frame for the game
 void game_render_frame_mono(int flip)
 {
+	fix eye_offset = 0;
+
+	(void)flip;
+
+#ifdef USE_OPENVR
+	if (vr_openvr_active())
+	{
+		const int eye = vr_openvr_current_eye();
+		if (eye >= 0)
+			eye_offset = vr_openvr_eye_offset(eye);
+	}
+#endif
+
 	gr_set_current_canvas(&Screen_3d_window);
 	
-	render_frame(0);
+	render_frame(eye_offset);
 
 	update_cockpits();
 
@@ -618,4 +634,3 @@ void show_boxed_message(char *msg, int RenderFlag)
 	if (!RenderFlag)
 		gr_flip();
 }
-


### PR DESCRIPTION
### Motivation
- In D1 VR gameplay the world was always rendered with `eye_offset=0`, causing stereoscopic “doubling” because both eyes were effectively drawn from the same viewpoint.
- The goal is to align D1’s in-game render path with D2 by applying the per-eye OpenVR offset when VR is active.

### Description
- Added a guarded include of `vr_openvr.h` (`#ifdef USE_OPENVR`) to `d1/main/gamerend.c` so OpenVR APIs are available when built with VR support.
- Compute a per-frame `eye_offset` in `game_render_frame_mono` by querying `vr_openvr_current_eye()` and `vr_openvr_eye_offset(eye)` when `vr_openvr_active()` is true.
- Pass the computed `eye_offset` into `render_frame(eye_offset)` instead of calling `render_frame(0)` so gameplay rendering uses the currently bound VR eye.
- Only `d1/main/gamerend.c` was modified and non-VR code paths are unchanged.

### Testing
- Ran `rg -n "game_render_frame_mono|vr_openvr_current_eye|render_frame\(eye_offset\)" d1/main/gamerend.c` to verify the new references are present and the change applied; the search succeeded.
- Inspected the updated file range with `nl -ba d1/main/gamerend.c | sed -n '40,70p;460,500p'` to confirm the new logic and include are in the expected locations; inspection succeeded.
- Verified the working tree reflected only the intended change to `d1/main/gamerend.c` using repository status checks; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985734bfc2c83309c957168d43a9f44)