### PR TITLE
Fix D1 menu screen mode after quitting in-game

### DIFF
--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -1040,6 +1040,7 @@ int game_handler(window *wind, d_event *event, void *data)
 				newdemo_stop_playback();
 
 			songs_play_song( SONG_TITLE, 1 );
+			set_screen_mode(SCREEN_MENU);
 
 			game_disable_cheats();
 			Game_mode = GM_GAME_OVER;


### PR DESCRIPTION
### Motivation
- Quitting from in-game left the main menu rendered in stereoscopic/VR mode instead of switching back to the normal menu canvas, so the UI must explicitly revert to the menu screen mode.

### Description
- Add a call to `set_screen_mode(SCREEN_MENU);` in the `EVENT_WINDOW_CLOSE` branch of `game_handler` in `d1/main/game.c` so the menu returns to `SCREEN_MENU` when leaving gameplay.

### Testing
- Verified the change by inspecting `d1/main/game.c` and confirming the inserted `set_screen_mode(SCREEN_MENU);` line via `rg -n`, `sed -n`, and `nl -ba` outputs, and by checking the working-tree diff to ensure the modification is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857af0d0808330bf6cd3616f84a523)