### PR TITLE
d1: match D2 VR menu scaling and fix stereo-doubled controls menu

### DIFF
--- a/d1/main/game.c
+++ b/d1/main/game.c
@@ -1040,6 +1040,7 @@ int game_handler(window *wind, d_event *event, void *data)
 				newdemo_stop_playback();
 
 			songs_play_song( SONG_TITLE, 1 );
+			set_screen_mode(SCREEN_MENU);
 
 			game_disable_cheats();
 			Game_mode = GM_GAME_OVER;

--- a/d1/main/kconfig.c
+++ b/d1/main/kconfig.c
@@ -22,6 +22,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <string.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <math.h>
 
 #include "dxxerror.h"
 #include "pstypes.h"
@@ -52,6 +53,9 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "cntrlcen.h"
 #include "collide.h"
 #include "playsave.h"
+#ifdef USE_OPENVR
+#include "vr_openvr.h"
+#endif
 
 #ifdef OGL
 #include "ogl_init.h"
@@ -111,6 +115,10 @@ typedef struct kc_menu
 	window	*wind;
 	kc_item	*items;
 	const char	*title;
+	int	base_x;
+	int	base_y;
+	int	width;
+	int	height;
 	int	nitems;
 	int	citem;
 	int	old_jaxis[JOY_MAX_AXES];
@@ -119,6 +127,38 @@ typedef struct kc_menu
 	ubyte	q_fade_i;	// for flashing the question mark
 	ubyte	mouse_state;
 } kc_menu;
+
+#ifdef USE_OPENVR
+static void kconfig_vr_offset(int *x, int *y)
+{
+	int offset_x = 0;
+	int offset_y = 0;
+
+	if (vr_openvr_active())
+	{
+		const int eye = vr_openvr_current_eye();
+		float l = 0.0f;
+		float r = 0.0f;
+		float b = 0.0f;
+		float t = 0.0f;
+
+		if (eye >= 0 && vr_openvr_eye_projection(eye, &l, &r, &b, &t))
+		{
+			const float width = (float)grd_curscreen->sc_canvas.cv_bitmap.bm_w;
+			const float height = (float)grd_curscreen->sc_canvas.cv_bitmap.bm_h;
+			const float x_ndc = (r + l) / (r - l);
+			const float y_ndc = (t + b) / (t - b);
+			const int center_x = (int)lroundf((-x_ndc * 0.5f + 0.5f) * width);
+			const int center_y = (int)lroundf((0.5f - 0.5f * y_ndc) * height);
+			offset_x = center_x - (grd_curscreen->sc_canvas.cv_bitmap.bm_w / 2);
+			offset_y = center_y - (grd_curscreen->sc_canvas.cv_bitmap.bm_h / 2);
+		}
+	}
+
+	*x = offset_x;
+	*y = offset_y;
+}
+#endif
 
 const ubyte DefaultKeySettings[3][MAX_CONTROLS] = {
 {0xc8,0x48,0xd0,0x50,0xcb,0x4b,0xcd,0x4d,0x38,0xff,0xff,0x4f,0xff,0x51,0xff,0x4a,0xff,0x4e,0xff,0xff,0x10,0x47,0x12,0x49,0x1d,0x9d,0x39,0xff,0x21,0xff,0x1e,0xff,0x2c,0xff,0x30,0xff,0x13,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xf,0xff,0x33,0x0,0x34,0x0},
@@ -451,6 +491,20 @@ void kconfig_draw(kc_menu *menu)
 
 	gr_set_current_canvas(NULL);
 	nm_draw_background(((SWIDTH-w)/2)-BORDERX,((SHEIGHT-h)/2)-BORDERY,((SWIDTH-w)/2)+w+BORDERX,((SHEIGHT-h)/2)+h+BORDERY);
+#ifdef USE_OPENVR
+	{
+		int offset_x = 0;
+		int offset_y = 0;
+
+		if (vr_openvr_active())
+		{
+			kconfig_vr_offset(&offset_x, &offset_y);
+			gr_init_sub_canvas(window_get_canvas(menu->wind), &grd_curscreen->sc_canvas,
+							   menu->base_x + offset_x, menu->base_y + offset_y,
+							   menu->width, menu->height);
+		}
+	}
+#endif
 
 	gr_set_current_canvas(window_get_canvas(menu->wind));
 
@@ -909,9 +963,13 @@ void kconfig_sub(kc_item * items,int nitems, char *title)
 	menu->citem = 0;
 	menu->changing = 0;
 	menu->mouse_state = 0;
+	menu->base_x = (SWIDTH - FSPACX(320))/2;
+	menu->base_y = (SHEIGHT - FSPACY(200))/2;
+	menu->width = FSPACX(320);
+	menu->height = FSPACY(200);
 
-	if (!(menu->wind = window_create(&grd_curscreen->sc_canvas, (SWIDTH - FSPACX(320))/2, (SHEIGHT - FSPACY(200))/2, FSPACX(320), FSPACY(200),
-					   (int (*)(window *, d_event *, void *))kconfig_handler, menu)))
+	if (!(menu->wind = window_create(&grd_curscreen->sc_canvas, menu->base_x, menu->base_y, menu->width, menu->height,
+				   (int (*)(window *, d_event *, void *))kconfig_handler, menu)))
 		d_free(menu);
 }
 

--- a/d1/main/newmenu.c
+++ b/d1/main/newmenu.c
@@ -22,6 +22,7 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include <string.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <math.h>
 
 #include "pstypes.h"
 #include "dxxerror.h"
@@ -57,6 +58,9 @@ COPYRIGHT 1993-1998 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "playsave.h"
 #include "automap.h"
 #include "rbaudio.h"
+#ifdef USE_OPENVR
+#include "vr_openvr.h"
+#endif
 
 #ifdef OGL
 #include "ogl_init.h"
@@ -72,6 +76,7 @@ struct newmenu
 {
 	window			*wind;
 	int				x,y,w,h;
+	int				base_x, base_y;
 	short			swidth, sheight; float fntscalex, fntscaley; // with these we check if resolution or fonts have changed so menu structure can be recreated
 	char			*title;
 	char			*subtitle;
@@ -96,6 +101,38 @@ grs_bitmap nm_background, nm_background1;
 grs_bitmap *nm_background_sub = NULL;
 
 newmenu *newmenu_do4( char * title, char * subtitle, int nitems, newmenu_item * item, int (*subfunction)(newmenu *menu, d_event *event, void *userdata), void *userdata, int citem, char * filename, int TinyMode, int TabsFlag );
+
+#ifdef USE_OPENVR
+static void menu_vr_offset(int *x, int *y)
+{
+	int offset_x = 0;
+	int offset_y = 0;
+
+	if (vr_openvr_active())
+	{
+		const int eye = vr_openvr_current_eye();
+		float l = 0.0f;
+		float r = 0.0f;
+		float b = 0.0f;
+		float t = 0.0f;
+
+		if (eye >= 0 && vr_openvr_eye_projection(eye, &l, &r, &b, &t))
+		{
+			const float width = (float)grd_curcanv->cv_bitmap.bm_w;
+			const float height = (float)grd_curcanv->cv_bitmap.bm_h;
+			const float x_ndc = (r + l) / (r - l);
+			const float y_ndc = (t + b) / (t - b);
+			const int center_x = (int)lroundf((-x_ndc * 0.5f + 0.5f) * width);
+			const int center_y = (int)lroundf((0.5f - 0.5f * y_ndc) * height);
+			offset_x = center_x - (grd_curcanv->cv_bitmap.bm_w / 2);
+			offset_y = center_y - (grd_curcanv->cv_bitmap.bm_h / 2);
+		}
+	}
+
+	*x = offset_x;
+	*y = offset_y;
+}
+#endif
 
 void newmenu_free_background()	{
 	if (nm_background.bm_data)
@@ -1398,14 +1435,44 @@ int newmenu_draw(window *wind, newmenu *menu)
 	int th = 0, ty, sx, sy;
 	int i;
 	int string_width, string_height, average_width;
+	int refresh_canvas = 0;
+#ifdef USE_OPENVR
+	const float vr_menu_scale = (vr_openvr_active() && Screen_mode == SCREEN_GAME) ? 0.5f : 0.8f;
+	const float saved_fnt_scale_x = FNTScaleX;
+	const float saved_fnt_scale_y = FNTScaleY;
+
+	if (vr_menu_scale != 1.0f)
+	{
+		FNTScaleX = saved_fnt_scale_x * vr_menu_scale;
+		FNTScaleY = saved_fnt_scale_y * vr_menu_scale;
+	}
+#endif
 
 	if (menu->swidth != SWIDTH || menu->sheight != SHEIGHT || menu->fntscalex != FNTScaleX || menu->fntscalex != FNTScaleY)
 	{
 		newmenu_create_structure ( menu );
-		if (menu_canvas)
+		refresh_canvas = 1;
+	}
+
+#ifdef USE_OPENVR
+	{
+		int offset_x = 0;
+		int offset_y = 0;
+
+		menu->x = menu->base_x;
+		menu->y = menu->base_y;
+		if (vr_openvr_active())
 		{
-			gr_init_sub_canvas(menu_canvas, &grd_curscreen->sc_canvas, menu->x, menu->y, menu->w, menu->h);
+			menu_vr_offset(&offset_x, &offset_y);
+			refresh_canvas = 1;
 		}
+		menu->x += offset_x;
+		menu->y += offset_y;
+	}
+#endif
+	if (menu_canvas && refresh_canvas)
+	{
+		gr_init_sub_canvas(menu_canvas, &grd_curscreen->sc_canvas, menu->x, menu->y, menu->w, menu->h);
 	}
 
 	gr_set_current_canvas( NULL );
@@ -1472,6 +1539,13 @@ int newmenu_draw(window *wind, newmenu *menu)
 	}
 
 	gr_set_current_canvas(save_canvas);
+#ifdef USE_OPENVR
+	if (vr_menu_scale != 1.0f)
+	{
+		FNTScaleX = saved_fnt_scale_x;
+		FNTScaleY = saved_fnt_scale_y;
+	}
+#endif
 
 	return 1;
 }
@@ -1587,10 +1661,24 @@ newmenu *newmenu_do4( char * title, char * subtitle, int nitems, newmenu_item * 
 	}
 
 	menu->max_displayable=nitems;
+	menu->base_x = 0;
+	menu->base_y = 0;
 
 	//set_screen_mode(SCREEN_MENU);	//hafta set the screen mode here or fonts might get changed/freed up if screen res changes
 
 	newmenu_create_structure(menu);
+#ifdef USE_OPENVR
+	{
+		int offset_x = 0;
+		int offset_y = 0;
+
+		menu->base_x = menu->x;
+		menu->base_y = menu->y;
+		menu_vr_offset(&offset_x, &offset_y);
+		menu->x += offset_x;
+		menu->y += offset_y;
+	}
+#endif
 
 	// Create the basic window
 	if (menu)


### PR DESCRIPTION
### Motivation
- In D1 the in-game menus render too large in VR compared to D2 so menus must be scaled the same way as D2 when VR is active. 
- The Controls menu in D1 appeared stereo-doubled in VR and needs the same per-eye offset handling that was applied in D2. 
- Quitting from gameplay must restore the main menu mode so the UI uses the normal menu canvas.

### Description
- Add OpenVR support and math include hooks and implement per-eye eye-offset helpers `menu_vr_offset` and `kconfig_vr_offset` to compute the menu offsets from the VR projection. 
- Update `d1/main/newmenu.c` to track `base_x/base_y`, apply D2-like VR font scaling (`0.5` in-game, `0.8` otherwise), apply per-eye offsets before initializing sub-canvases in `newmenu_draw`, and restore font scales after drawing. 
- Update `d1/main/kconfig.c` to store window base geometry (`base_x/base_y/width/height`) in `kc_menu` and reinitialize the controls sub-canvas per-eye so the Controls UI is not stereo-doubled. 
- Ensure the main menu returns to normal after leaving gameplay by calling `set_screen_mode(SCREEN_MENU);` in the game window close path (`d1/main/game.c`).

### Testing
- Ran `git diff --check` to validate the patch formatting and it passed. 
- Verified repository state with `git status --short` and `git log --oneline -2` to confirm the intended changes were committed. 
- Inspected modified functions and regions with `rg` and `sed` outputs to confirm the D2 parity logic was applied, and noted there is no local `build` directory so a full compile run was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857af0d0808330bf6cd3616f84a523)