### PR TITLE
Fix VR automap subcanvas orientation

### DIFF
--- a/d2/main/automap.c
+++ b/d2/main/automap.c
@@ -543,9 +543,13 @@ static void draw_automap_to_canvas(automap *am)
 
 	{
 		const int map_x = (grd_curcanv->cv_bitmap.bm_w/23);
-		const int map_y = (grd_curcanv->cv_bitmap.bm_h/6);
 		const int map_w = (grd_curcanv->cv_bitmap.bm_w/1.1);
 		const int map_h = (grd_curcanv->cv_bitmap.bm_h/1.45);
+		int map_y = (grd_curcanv->cv_bitmap.bm_h/6);
+
+		if (am->rendering_to_vr_texture)
+			map_y = grd_curcanv->cv_bitmap.bm_h - map_y - map_h;
+
 		gr_init_sub_canvas(&am->automap_view, grd_curcanv, map_x, map_y, map_w, map_h);
 	}
 


### PR DESCRIPTION
### Motivation
- Fix the automap subcanvas Y-origin when rendering the automap into the VR menu texture so the 3D map and level-name text no longer appear upside down in VR.

### Description
- When creating the automap subcanvas the code now conditionally mirrors the Y placement while rendering to the VR menu texture by checking `am->rendering_to_vr_texture` and applying `map_y = grd_curcanv->cv_bitmap.bm_h - map_y - map_h` before calling `gr_init_sub_canvas` in `d2/main/automap.c`.

### Testing
- Ran `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698588f19e2c8330941aa139022c1789)