### PR TITLE
D1: Apply per‑eye VR offsets to cockpit/HUD to fix stereo‑doubling

### DIFF
--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -530,6 +530,11 @@ extern void ogl_loadbmtexture(grs_bitmap *bm, int filter_blueship_wing);
 // This actually renders the new cockpit onto the screen.
 void update_cockpits()
 {
+	int cockpit_offset_x = 0;
+	int cockpit_offset_y = 0;
+
+	cockpit_gauge_offset(&cockpit_offset_x, &cockpit_offset_y);
+
 	if (is_observer() && !can_draw_observer_cockpit()) {
 		// Do not draw cockpit.
 	} else {
@@ -544,17 +549,17 @@ void update_cockpits()
 			case CM_FULL_COCKPIT:
 				gr_set_current_canvas(NULL);
 	#ifdef OGL
-				ogl_ubitmapm_cs (0, 0, -1, grd_curcanv->cv_bitmap.bm_h, bm,255, F1_0);
+				ogl_ubitmapm_cs (cockpit_offset_x, cockpit_offset_y, -1, grd_curcanv->cv_bitmap.bm_h, bm,255, F1_0);
 	#else
-				gr_ubitmapm(0,0, bm);
+				gr_ubitmapm(cockpit_offset_x,cockpit_offset_y, bm);
 	#endif
 				break;
 			case CM_REAR_VIEW:
 				gr_set_current_canvas(NULL);
 	#ifdef OGL
-				ogl_ubitmapm_cs (0, 0, -1, grd_curcanv->cv_bitmap.bm_h, bm,255, F1_0);
+				ogl_ubitmapm_cs (cockpit_offset_x, cockpit_offset_y, -1, grd_curcanv->cv_bitmap.bm_h, bm,255, F1_0);
 	#else
-				gr_ubitmapm(0,0, bm);
+				gr_ubitmapm(cockpit_offset_x,cockpit_offset_y, bm);
 	#endif
 				break;
 			case CM_FULL_SCREEN:
@@ -563,9 +568,9 @@ void update_cockpits()
 			case CM_STATUS_BAR:
 				gr_set_current_canvas(NULL);
 	#ifdef OGL
-				ogl_ubitmapm_cs (0, (HIRESMODE?(SHEIGHT*2)/2.6:(SHEIGHT*2)/2.72), -1, ((int) ((double) (bm->bm_h) * (HIRESMODE?(double)SHEIGHT/480:(double)SHEIGHT/200) + 0.5)), bm,255, F1_0);
+				ogl_ubitmapm_cs (cockpit_offset_x, cockpit_offset_y + (HIRESMODE?(SHEIGHT*2)/2.6:(SHEIGHT*2)/2.72), -1, ((int) ((double) (bm->bm_h) * (HIRESMODE?(double)SHEIGHT/480:(double)SHEIGHT/200) + 0.5)), bm,255, F1_0);
 	#else
-				gr_ubitmapm(0,SHEIGHT-bm->bm_h,bm);
+				gr_ubitmapm(cockpit_offset_x,cockpit_offset_y + SHEIGHT-bm->bm_h,bm);
 	#endif
 				break;
 			case CM_LETTERBOX:

--- a/d1/main/gauges.h
+++ b/d1/main/gauges.h
@@ -36,6 +36,7 @@ extern bitmap_index Gauges[MAX_GAUGE_BMS_MAC];   // Array of all gauge bitmaps.
 
 extern void add_points_to_score(int points);
 extern void add_bonus_points_to_score(int points);
+extern void cockpit_gauge_offset(int *x, int *y);
 
 void render_gauges(void);
 void init_gauges(void);
@@ -91,5 +92,5 @@ extern span weapon_window_left[],weapon_window_left_hires[],weapon_window_right[
 #define RET_COLOR_DEFAULT_A     0
 
 #endif
- 
+
 extern int Observer_message_y_start;


### PR DESCRIPTION
### Motivation
- In D1 the cockpit frame, HUD gauges and text were visually doubled in stereoscopic VR because 2D overlays were drawn at a single fixed screen origin rather than aligned to each eye's projection center.
- The D2 code already computes per‑eye offsets for OpenVR; this change backports the same approach to D1 to align HUD/cockpit elements with each eye and eliminate stereo doubling.

### Description
- Added a `cockpit_gauge_offset(int *x, int *y)` helper to `d1/main/gauges.c` and exposed it in `d1/main/gauges.h`, which computes per‑eye X/Y offsets from the OpenVR eye projection when `USE_OPENVR` is enabled.
- Applied the computed offset to cockpit frame rendering in `d1/main/gamerend.c::update_cockpits()` so cockpit bitmaps are drawn at the per‑eye center instead of a fixed origin.
- Updated `d1/main/gauges.c` HUD blit helpers (`hud_bitblt` / `hud_bitblt_free`) to add the per‑eye offset when drawing gauge bitmaps so gauges follow the eye center.
- Updated `d1/main/hud.c` HUD message rendering to account for a VR top margin and apply the per‑eye offsets to centered HUD text, preventing stereo‑doubled text overlays.

### Testing
- Performed a code consistency check using `git diff --check`, which reported no issues.
- Attempted to configure a local D1 build with `cmake -S d1 -B build-d1 -DCMAKE_BUILD_TYPE=Release`, but configuration failed in this environment due to the missing SDL2 CMake package (external dependency), so a full build/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985897dc9cc83309326a394f688cc32)