### PR TITLE
Add VR per-eye rendering path in D1 to avoid stereo doubling

### DIFF
--- a/d1/main/gamerend.c
+++ b/d1/main/gamerend.c
@@ -51,6 +51,7 @@ COPYRIGHT 1993-1999 PARALLAX SOFTWARE CORPORATION.  ALL RIGHTS RESERVED.
 #include "mission.h"
 #include "gameseq.h"
 #include "args.h"
+#include "vr_openvr.h"
 
 #ifdef OGL
 #include "ogl_init.h"
@@ -463,6 +464,37 @@ extern int gr_bitblt_double;
 extern int force_cockpit_redraw;
 void update_cockpits();
 
+static void game_render_frame_eye(fix eye_offset)
+{
+	gr_set_current_canvas(&Screen_3d_window);
+	
+	render_frame(eye_offset);
+
+	update_cockpits();
+
+	if (Newdemo_state == ND_STATE_PLAYBACK)
+		Game_mode = Newdemo_game_mode;
+
+	if (is_observer() && !can_draw_observer_cockpit()) {
+		// Do not render gauges.
+	} else {
+		if (PlayerCfg.CurrentCockpitMode==CM_FULL_COCKPIT || PlayerCfg.CurrentCockpitMode==CM_STATUS_BAR)
+			render_gauges();
+	}
+
+	if (Newdemo_state == ND_STATE_PLAYBACK)
+		Game_mode = GM_NORMAL | (Game_mode & GM_OBSERVER);
+
+	gr_set_current_canvas(&Screen_3d_window);
+
+	game_draw_hud_stuff();
+
+#ifdef NETWORK
+	if (netplayerinfo_on && Game_mode & GM_MULTI)
+		show_netplayerinfo();
+#endif
+}
+
 //render a frame for the game
 void game_render_frame_mono(int flip)
 {
@@ -493,6 +525,11 @@ void game_render_frame_mono(int flip)
 	if (netplayerinfo_on && Game_mode & GM_MULTI)
 		show_netplayerinfo();
 #endif
+}
+
+static void game_render_frame_vr(void)
+{
+	game_render_frame_eye(vr_openvr_eye_offset(vr_openvr_current_eye()));
 }
 
 void toggle_cockpit()
@@ -598,7 +635,10 @@ void game_render_frame()
 {
 	set_screen_mode( SCREEN_GAME );
 	play_homing_warning();
-	game_render_frame_mono(GameArg.DbgUseDoubleBuffer);
+	if (vr_openvr_active())
+		game_render_frame_vr();
+	else
+		game_render_frame_mono(GameArg.DbgUseDoubleBuffer);
 }
 
 //show a message in a nice little box
@@ -623,4 +663,3 @@ void show_boxed_message(char *msg, int RenderFlag)
 	if (!RenderFlag)
 		gr_flip();
 }
-


### PR DESCRIPTION
### Motivation
- D1 was rendering the 3D view twice when VR was active (stereo-doubling) while D2 already uses a per-eye render path, so D1 needs a similar VR-aware rendering path.

### Description
- Include `vr_openvr.h` and add a new helper `game_render_frame_eye(fix eye_offset)` that renders a single eye using the existing `render_frame` path and then draws HUD, gauges and netplayer info.
- Add `game_render_frame_vr()` which invokes the per-eye helper with the current OpenVR eye offset returned by `vr_openvr_eye_offset()`.
- Update `game_render_frame()` to choose the VR path when `vr_openvr_active()` is true, otherwise fall back to the existing mono renderer `game_render_frame_mono()`.
- Keep cockpit/update logic and HUD rendering behavior identical while reusing existing `render_frame(eye_offset)` so the changes are minimal and leverage current rendering flow (file modified: `d1/main/gamerend.c`).

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859629954c833086c3e2c17282b729)