### PR TITLE
Use OpenVR per-eye projection in D1 OpenGL renderer

### DIFF
--- a/d1/arch/ogl/ogl.c
+++ b/d1/arch/ogl/ogl.c
@@ -35,6 +35,7 @@
 #include "rle.h"
 #include "console.h"
 #include "u_mem.h"
+#include "vr_openvr.h"
 #ifdef HAVE_LIBPNG
 #include "pngfile.h"
 #endif
@@ -1157,7 +1158,19 @@ void ogl_start_frame(void){
 #ifdef OGLES
 	perspective(90.0,1.0,0.1,5000.0);   
 #else
-	gluPerspective(90.0,1.0,0.1,5000.0);
+	{
+		int eye = vr_openvr_current_eye();
+		float l = 0.0f;
+		float r = 0.0f;
+		float b = 0.0f;
+		float t = 0.0f;
+		const float near_z = 0.1f;
+		const float far_z = 5000.0f;
+		if (eye >= 0 && vr_openvr_eye_projection(eye, &l, &r, &b, &t))
+			glFrustum(l * near_z, r * near_z, t * near_z, b * near_z, near_z, far_z);
+		else
+			gluPerspective(90.0,1.0,near_z,far_z);
+	}
 #endif
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();//clear matrix


### PR DESCRIPTION
### Motivation
- Ensure the 3D scene uses the same stereo/projection corrections as the HUD by using OpenVR per-eye projections when rendering in Descent 1 OpenGL.

### Description
- Add `#include "vr_openvr.h"` and modify `ogl_start_frame()` in `d1/arch/ogl/ogl.c` to call `vr_openvr_current_eye()` and `vr_openvr_eye_projection()` and build a per-eye frustum with `glFrustum()` when available, falling back to `gluPerspective()` otherwise.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985a455d0a48330951eda22d0ea7590)