### PR TITLE
Add debug output for object creation failures

### DIFF
--- a/d2/main/object.c
+++ b/d2/main/object.c
@@ -1292,8 +1292,10 @@ int obj_create(enum object_type_t type,ubyte id,int segnum,const vms_vector *pos
 	object *obj;
 
 	// Some consistency checking. FIXME: Add more debug output here to probably trace all possible occurances back.
-	if (segnum < 0 || segnum > Highest_segment_index)
+	if (segnum < 0 || segnum > Highest_segment_index) {
+		con_printf(CON_DEBUG, "obj_create: Bad segnum %d (max=%d) type=%d id=%d\n", segnum, Highest_segment_index, type, id);
 		return -1;
+	}
 
 	Assert(ctype <= CT_CNTRLCEN);
 


### PR DESCRIPTION
This is a generated PR. It tries to optimize things no idea if it's useful or anything but you can decide.

---

Added debug output to `obj_create` in `d2/main/object.c` to trace object creation failures when the segment number is invalid. This addresses the FIXME comment and helps in diagnosing object creation issues.

---
*PR created automatically by Jules for task [1661302023725998831](https://jules.google.com/task/1661302023725998831) started by @arran4*