### PR TITLE
Add debug output for object creation failures

### DIFF
--- a/d1/main/object.c
+++ b/d1/main/object.c
@@ -1186,8 +1186,10 @@ int obj_create(enum object_type_t type, ubyte id,int segnum,vms_vector *pos,
 	object *obj;
 
 	// Some consistency checking. FIXME: Add more debug output here to probably trace all possible occurances back.
-	if (segnum < 0 || segnum > Highest_segment_index)
+	if (segnum < 0 || segnum > Highest_segment_index) {
+		con_printf(CON_URGENT, "obj_create: Bad segment number %d (Highest=%d) for object type %d, id %d\n", segnum, Highest_segment_index, type, id);
 		return -1;
+	}
 
 	Assert(ctype <= CT_CNTRLCEN);
 


### PR DESCRIPTION
Automated help.. Not sure if it's even useful or relevant to what you're doing... It's just a log

---

Added con_printf(CON_URGENT, ...) to obj_create in d1/main/object.c to trace failures when segment number is invalid.

---
*PR created automatically by Jules for task [15427646110673861680](https://jules.google.com/task/15427646110673861680) started by @arran4*