### PR TITLE
Fix MVE decoder crash with bounds checking and optimized buffer size

### DIFF
--- a/d2/libmve/decoder16.c
+++ b/d2/libmve/decoder16.c
@@ -149,10 +149,20 @@ static void genLoopkupTable()
 static void copyFrame(unsigned short *pDest, unsigned short *pSrc)
 {
     int i;
+    unsigned char *pSrcByte;
+    unsigned char *limit = (unsigned char *)g_vBuffers + g_width * g_height * 4;
 
     for (i=0; i<8; i++)
     {
-        memcpy(pDest, pSrc, 16);
+        pSrcByte = (unsigned char *)pSrc;
+        if (pSrcByte >= (unsigned char *)g_vBuffers && pSrcByte + 16 <= limit)
+        {
+            memcpy(pDest, pSrc, 16);
+        }
+        else
+        {
+            memset(pDest, 0, 16);
+        }
         pDest += g_width;
         pSrc += g_width;
     }

--- a/d2/libmve/decoder8.c
+++ b/d2/libmve/decoder8.c
@@ -68,10 +68,18 @@ static void relFar(int i, int sign, int *x, int *y)
 static void copyFrame(unsigned char *pDest, unsigned char *pSrc)
 {
 	int i;
+	unsigned char *limit = (unsigned char *)g_vBuffers + g_width * g_height * 4;
 
 	for (i=0; i<8; i++)
 	{
-		memcpy(pDest, pSrc, 8);
+		if (pSrc >= (unsigned char *)g_vBuffers && pSrc + 8 <= limit)
+		{
+			memcpy(pDest, pSrc, 8);
+		}
+		else
+		{
+			memset(pDest, 0, 8);
+		}
 		pDest += g_width;
 		pSrc += g_width;
 	}

--- a/d2/libmve/decoders.h
+++ b/d2/libmve/decoders.h
@@ -9,6 +9,7 @@
 
 extern int g_width, g_height;
 extern void *g_vBackBuf1, *g_vBackBuf2;
+extern void *g_vBuffers;
 
 extern void decodeFrame8(unsigned char *pFrame, unsigned char *pMap, int mapRemain, unsigned char *pData, int dataRemain);
 extern void decodeFrame16(unsigned char *pFrame, unsigned char *pMap, int mapRemain, unsigned char *pData, int dataRemain);

--- a/d2/libmve/mveplay.c
+++ b/d2/libmve/mveplay.c
@@ -554,7 +554,7 @@ static int create_videobuf_handler(unsigned char major, unsigned char minor, uns
 	/* TODO: * 4 causes crashes on some files */
 	/* only malloc once */
 	if (g_vBuffers == NULL)
-		g_vBackBuf1 = g_vBuffers = mve_alloc(g_width * g_height * 8);
+		g_vBackBuf1 = g_vBuffers = mve_alloc(g_width * g_height * 4);
 	if (truecolor) {
 		g_vBackBuf2 = (unsigned short *)g_vBackBuf1 + (g_width * g_height);
 	} else {


### PR DESCRIPTION
Not sure if useful automated security thing thanks to jules.. Probalby not even relevant to the part your own technically should reduce crashes or increase speed but....

---

Investigated the crash occurring when using *4 buffer size allocation in libmve.
The crash was caused by motion compensation opcodes (e.g. 0x2) reading out of bounds of the allocated buffer when the buffer size was reduced from *8 (which provided implicit padding) to *4.
Implemented bounds checking in copyFrame functions in decoder8.c and decoder16.c to safely handle out-of-bounds reads by filling with black (0).
Changed allocation size in mveplay.c to *4 as requested, which is now safe due to the bounds checks.
Exposed g_vBuffers in decoders.h to facilitate bounds checking.

---
*PR created automatically by Jules for task [14606427605813531020](https://jules.google.com/task/14606427605813531020) started by @arran4*