### PR TITLE
Add debug output for object creation failures and fix build errors

### DIFF
--- a/d2/main/gamerend.c
+++ b/d2/main/gamerend.c
@@ -521,9 +521,9 @@ void game_draw_hud_stuff()
 #ifdef NETWORK
 	game_draw_multi_message();
 #endif
-#ifdef USE_OPENVR
         int offset_x = 0;
         int offset_y = 0;
+#ifdef USE_OPENVR
         cockpit_gauge_offset(&offset_x, &offset_y);
 #endif
 	game_draw_marker_message();

--- a/d2/main/gauges.c
+++ b/d2/main/gauges.c
@@ -1296,10 +1296,9 @@ void show_bomb_count(int x,int y,int bg_color,int always_show,int right_align)
 {
 	int bomb,count,w=0,h=0,aw=0;
 	char txt[5],*t;
-#ifdef USE_OPENVR
 	int offset_x = 0;
 	int offset_y = 0;
-
+#ifdef USE_OPENVR
 	cockpit_gauge_offset(&offset_x, &offset_y);
 #endif
 	int pnum = get_pnum_for_hud();
@@ -1728,12 +1727,11 @@ void hud_show_lives()
 {
 	int x;
 	int top_margin;
-#ifdef USE_OPENVR
 	int offset_x = 0;
 	int offset_y = 0;
 	int cockpit_offset_x = 0;
 	int cockpit_offset_y = 0;
-
+#ifdef USE_OPENVR
 	cockpit_gauge_offset(&offset_x, &offset_y);
 #endif
 	int pnum = get_pnum_for_hud();
@@ -5604,7 +5602,7 @@ void do_cockpit_window_view(int win,object *viewer,int rear_view_flag,int user,c
 #ifdef USE_OPENVR
 		gr_init_sub_canvas(&window_canv,&grd_curscreen->sc_canvas,HUD_SCALE_X(box->left) + offset_x,HUD_SCALE_Y(box->top)+offset_y,HUD_SCALE_X(box->right-box->left+1),HUD_SCALE_Y(box->bot-box->top+1));
 #else
-		gr_init_sub_canvas(&window_canv,&grd_curscreen->sc_canvas,HUD_SCALE_X(box->left,HUD_SCALE_Y(box->top),HUD_SCALE_X(box->right-box->left+1),HUD_SCALE_Y(box->bot-box->top+1));
+		gr_init_sub_canvas(&window_canv,&grd_curscreen->sc_canvas,HUD_SCALE_X(box->left),HUD_SCALE_Y(box->top),HUD_SCALE_X(box->right-box->left+1),HUD_SCALE_Y(box->bot-box->top+1));
 #endif
 	}
 

--- a/d2/main/object.c
+++ b/d2/main/object.c
@@ -1292,8 +1292,10 @@ int obj_create(enum object_type_t type,ubyte id,int segnum,const vms_vector *pos
 	object *obj;
 
 	// Some consistency checking. FIXME: Add more debug output here to probably trace all possible occurances back.
-	if (segnum < 0 || segnum > Highest_segment_index)
+	if (segnum < 0 || segnum > Highest_segment_index) {
+		con_printf(CON_DEBUG, "obj_create: Bad segnum %d (highest %d) for object type %d\n", segnum, Highest_segment_index, type);
 		return -1;
+	}
 
 	Assert(ctype <= CT_CNTRLCEN);
 


### PR DESCRIPTION
@DMJC this one actually seems relevant. No idea if it's any good you will have to assess that yourself.

---

This change addresses the request to add debug output to `d2/main/object.c` when object creation fails due to an invalid segment number. It adds a `con_printf(CON_DEBUG, ...)` call to log the segment number, highest valid segment index, and object type.

Additionally, this change fixes pre-existing build errors encountered during verification:
- In `d2/main/gamerend.c`, `offset_x` and `offset_y` declarations were moved outside of `#ifdef USE_OPENVR` block as they are used unconditionally.
- In `d2/main/gauges.c`, `offset_x`, `offset_y`, `cockpit_offset_x`, and `cockpit_offset_y` declarations were moved outside of `#ifdef USE_OPENVR` blocks.
- In `d2/main/gauges.c`, a syntax error in `gr_init_sub_canvas` call (malformed `HUD_SCALE_X` macro usage) was fixed.

Verification:
- Configured and built `d2` using CMake (`d2x-redux` target).
- Verified the build succeeded.
- Ran the executable (`d2x-redux --help`) to confirm it starts (smoke test).
- Verified the code logic for the debug output.

---
*PR created automatically by Jules for task [12379164890410689798](https://jules.google.com/task/12379164890410689798) started by @arran4*