### PR TITLE
Fix out-of-bounds access in multiplayer packet handling

### DIFF
--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -2078,6 +2078,9 @@ multi_do_fire(const ubyte *buf)
     
 	// Act out the actual shooting
 	pnum = buf[1];
+	if (pnum < 0 || pnum >= N_players)
+		return;
+
 	weapon = (int)buf[2];
 	flags = buf[4];
 	Network_laser_track = GET_INTEL_SHORT(buf + 6);
@@ -2201,6 +2204,8 @@ multi_do_position(const ubyte *buf)
 #endif
 
 	pnum = buf[1];
+	if (pnum >= N_players)
+		return;
 
 #ifndef WORDS_BIGENDIAN
 	extract_shortpos(&Objects[Players[pnum].objnum], (shortpos *)(buf + 2),0);
@@ -2221,6 +2226,12 @@ multi_do_reappear(const ubyte *buf)
 	ubyte pnum = buf[1];
 
 	objnum = GET_INTEL_SHORT(buf + 2);
+
+	if (pnum >= N_players)
+		return;
+
+	if ((objnum < 0) || (objnum > Highest_object_index))
+		return;
 
 	Assert(objnum >= 0);
 	if (pnum != Objects[objnum].id)
@@ -2699,6 +2710,9 @@ multi_do_cloak(const ubyte *buf)
 
 	pnum = buf[1];
 
+	if (pnum < 0 || pnum >= N_players)
+		return;
+
 	Assert(pnum < N_players);
 
 	Players[pnum].flags |= PLAYER_FLAGS_CLOAKED;
@@ -2719,6 +2733,9 @@ multi_do_decloak(const ubyte *buf)
 
 	pnum = buf[1];
 
+	if (pnum < 0 || pnum >= N_players)
+		return;
+
 	if (Newdemo_state == ND_STATE_RECORDING)
 		newdemo_record_multi_decloak(pnum);
 
@@ -2730,6 +2747,9 @@ multi_do_invuln(const ubyte *buf)
 	int pnum;
 
 	pnum = buf[1];
+
+	if (pnum < 0 || pnum >= N_players)
+		return;
 
 	Assert(pnum < N_players);
 
@@ -2877,6 +2897,9 @@ multi_do_play_sound(const ubyte *buf)
 	int pnum = buf[1];
 	int sound_num = buf[2];
 	fix volume = buf[3] << 12;
+
+	if (pnum < 0 || pnum >= N_players)
+		return;
 
 	if (!Players[pnum].connected)
 		return;


### PR DESCRIPTION
@DMJC  probably not relevant but useful? It should definitely be it's own pr once vetted

---

This PR fixes a security vulnerability where player numbers (`pnum`) and object numbers (`objnum`) received in network packets were used as array indices without proper bounds checking in release builds.

### 🎯 What
- Added explicit bounds checks for `pnum` against `N_players` (or `MAX_PLAYERS` context) in `multi_do_fire`, `multi_do_position`, `multi_do_reappear`, `multi_do_cloak`, `multi_do_decloak`, `multi_do_invuln`, and `multi_do_play_sound`.
- Added bounds check for `objnum` against `Highest_object_index` in `multi_do_reappear`.

### ⚠️ Risk
Previously, `Assert` macros were used for validation, which are typically compiled out in release builds. This allowed malicious packets to cause out-of-bounds memory access (read/write), potentially leading to crashes or code execution.

### 🛡️ Solution
Inserted explicit `if` checks that return early if the indices are invalid, ensuring memory safety regardless of build configuration.

---
*PR created automatically by Jules for task [4865054293521259345](https://jules.google.com/task/4865054293521259345) started by @arran4*