### PR TITLE
Add debug output to obj_create in D1 to trace segment errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ Thumbs.db
 *.app
 d*x-rebirth
 /*/out/install
+build_d1/
+build_d1_debug/

--- a/d1/main/object.c
+++ b/d1/main/object.c
@@ -1185,9 +1185,11 @@ int obj_create(enum object_type_t type, ubyte id,int segnum,vms_vector *pos,
 	int objnum;
 	object *obj;
 
-	// Some consistency checking. FIXME: Add more debug output here to probably trace all possible occurances back.
-	if (segnum < 0 || segnum > Highest_segment_index)
+	// Some consistency checking.
+	if (segnum < 0 || segnum > Highest_segment_index) {
+		con_printf(CON_DEBUG, "obj_create: Invalid segment number %d (Highest_segment_index=%d) for object type %d, id %d\n", segnum, Highest_segment_index, type, id);
 		return -1;
+	}
 
 	Assert(ctype <= CT_CNTRLCEN);
 


### PR DESCRIPTION
Debug logs and ignore files..... hardly worth it

---

Added con_printf(CON_DEBUG, ...) to obj_create in d1/main/object.c when segnum is invalid, as requested by the FIXME comment. Also updated .gitignore to ignore build directories.

---
*PR created automatically by Jules for task [4429422615526852253](https://jules.google.com/task/4429422615526852253) started by @arran4*