### PR TITLE
Fix off-by-one error in net_udp_read_endlevel_packet

### DIFF
--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -3570,7 +3570,7 @@ void net_udp_read_endlevel_packet( ubyte *data, int data_len, struct _sockaddr s
 	if (multi_i_am_master())
 	{
 		ubyte pnum = data[5];
-		if(pnum < 1 || pnum > MAX_PLAYERS || pnum == multi_who_is_master()) {
+		if(pnum < 1 || pnum >= MAX_PLAYERS || pnum == multi_who_is_master()) {
 			drop_rx_packet(data, "invalid player number"); 
 			return; 
 		}

--- a/d1/main/net_udp.c
+++ b/d1/main/net_udp.c
@@ -6947,11 +6947,11 @@ void net_udp_process_p2p_ping(ubyte *data, struct _sockaddr sender_addr, int dat
 	if(direct_ping) {
 		// Don't update master, non-existent player, or me
 		if( (from_player == multi_who_is_master()) || 
-			(from_player > MAX_PLAYERS) || 
+		(from_player >= MAX_PLAYERS) ||
 			(from_player == Player_num)) {
 
 			char log_comment[100];
-			snprintf(log_comment, 100, "Cannot update address -- illegal player num %d (==%d, >%d, == %d)", from_player,
+		snprintf(log_comment, 100, "Cannot update address -- illegal player num %d (==%d, >=%d, == %d)", from_player,
 				multi_who_is_master(), MAX_PLAYERS, Player_num); 
 			net_log_comment(log_comment); 
 		} else {
@@ -7013,7 +7013,7 @@ void net_udp_process_p2p_pong(ubyte *data, struct _sockaddr sender_addr, int dat
 		Netgame.players[from_player].ping = 9999;
 
 	// Don't update master, non-existent player, or me
-	if(from_player < 1 || from_player > MAX_PLAYERS || from_player == Player_num) {
+	if(from_player < 1 || from_player >= MAX_PLAYERS || from_player == Player_num) {
 		return;
 	}
 


### PR DESCRIPTION
@DMJC I feel if this was an issue someon would have logged a bug a long time ago.. 

---

🎯 **What:** Fixed an off-by-one vulnerability in `d1/main/net_udp.c` where `pnum` could be equal to `MAX_PLAYERS`, causing an out-of-bounds array access.
⚠️ **Risk:** If exploited, this could lead to memory corruption or crashes, as the `Players` array is accessed with an invalid index.
🛡️ **Solution:** Changed the condition `pnum > MAX_PLAYERS` to `pnum >= MAX_PLAYERS` to strictly enforce the array bounds.

---
*PR created automatically by Jules for task [10123785534167658939](https://jules.google.com/task/10123785534167658939) started by @arran4*