### PR TITLE
Fix out-of-bounds access in D1 multiplayer packet handling

### DIFF
--- a/d1/main/multi.c
+++ b/d1/main/multi.c
@@ -2089,7 +2089,8 @@ multi_do_fire(const ubyte *buf)
 	shot_orientation.z = (fix) GET_INTEL_INT(buf + 16); 
 
 
-	Assert (pnum < N_players);
+	if (pnum >= N_players)
+		return;
 
 	if (Objects[Players[pnum].objnum].type == OBJ_GHOST)
 		multi_make_ghost_player(pnum);
@@ -2202,6 +2203,9 @@ multi_do_position(const ubyte *buf)
 
 	pnum = buf[1];
 
+	if (pnum >= N_players)
+		return;
+
 #ifndef WORDS_BIGENDIAN
 	extract_shortpos(&Objects[Players[pnum].objnum], (shortpos *)(buf + 2),0);
 #else
@@ -2219,6 +2223,9 @@ multi_do_reappear(const ubyte *buf)
 {
 	short objnum;
 	ubyte pnum = buf[1];
+
+	if (pnum >= N_players)
+		return;
 
 	objnum = GET_INTEL_SHORT(buf + 2);
 
@@ -2699,7 +2706,8 @@ multi_do_cloak(const ubyte *buf)
 
 	pnum = buf[1];
 
-	Assert(pnum < N_players);
+	if (pnum >= N_players)
+		return;
 
 	Players[pnum].flags |= PLAYER_FLAGS_CLOAKED;
 	Players[pnum].cloak_time = GameTime64;
@@ -2731,7 +2739,8 @@ multi_do_invuln(const ubyte *buf)
 
 	pnum = buf[1];
 
-	Assert(pnum < N_players);
+	if (pnum >= N_players)
+		return;
 
 	Players[pnum].flags |= PLAYER_FLAGS_INVULNERABLE;
 	Players[pnum].invulnerable_time = GameTime64;
@@ -2785,6 +2794,9 @@ multi_do_create_explosion(const ubyte *buf)
 
 	pnum = buf[count++];
 
+	if (pnum >= N_players)
+		return;
+
 	create_small_fireball_on_object(&Objects[Players[pnum].objnum], F1_0, 1);
 }
 
@@ -2826,6 +2838,9 @@ multi_do_create_powerup(const ubyte *buf)
 	powerup_type = buf[count++];
 	segnum = GET_INTEL_SHORT(buf + count); count += 2;
 	objnum = GET_INTEL_SHORT(buf + count); count += 2;
+
+	if (pnum >= N_players)
+		return;
 
 	if ((segnum < 0) || (segnum > Highest_segment_index)) {
 		Int3();
@@ -2877,6 +2892,9 @@ multi_do_play_sound(const ubyte *buf)
 	int pnum = buf[1];
 	int sound_num = buf[2];
 	fix volume = buf[3] << 12;
+
+	if (pnum >= N_players)
+		return;
 
 	if (!Players[pnum].connected)
 		return;


### PR DESCRIPTION
More multiplayer issues..

---

This PR fixes multiple out-of-bounds access vulnerabilities in `d1/main/multi.c`. 

The primary issue identified was in `multi_do_position` where `pnum` (player number) read from a network packet was used to access the `Players` array without validation. This allowed an attacker to send a malicious packet with an invalid `pnum`, potentially causing memory corruption.

This pattern was found in several other functions handling network packets. I have added bounds checks (`if (pnum >= N_players) return;`) to the following functions:
- `multi_do_position`
- `multi_do_fire` (previously relied on `Assert` which is disabled in release builds)
- `multi_do_reappear`
- `multi_do_cloak`
- `multi_do_invuln`
- `multi_do_create_explosion`
- `multi_do_create_powerup`
- `multi_do_play_sound`

I verified the fix using a standalone reproduction script (`repro_exploit.c`) that mocks the game structures and calls the modified function logic to confirm that invalid inputs are blocked.


---
*PR created automatically by Jules for task [8755696383576618755](https://jules.google.com/task/8755696383576618755) started by @arran4*