### PR TITLE
Fix buffer overflow in command line argument processing in d1 and d2

### DIFF
--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -458,7 +458,7 @@ int main(int argc, char *argv[])
 			if(PHYSFSX_exists(filename,0))
 			{
 				strcpy(strstr(filename,".plr"),"\0");
-				strcpy(Players[Player_num].callsign, GameArg.SysUsePlayersDir? &filename[8] : filename);
+				snprintf(Players[Player_num].callsign, sizeof(Players[Player_num].callsign), "%s", GameArg.SysUsePlayersDir? &filename[8] : filename);
 				read_player_file();
 				WriteConfigFile();
 			}

--- a/d2/main/inferno.c
+++ b/d2/main/inferno.c
@@ -477,7 +477,7 @@ int main(int argc, char *argv[])
 			if(PHYSFSX_exists(filename,0))
 			{
 				strcpy(strstr(filename,".plr"),"\0");
-				strcpy(Players[Player_num].callsign, GameArg.SysUsePlayersDir? &filename[8] : filename);
+				snprintf(Players[Player_num].callsign, sizeof(Players[Player_num].callsign), "%s", GameArg.SysUsePlayersDir? &filename[8] : filename);
 				read_player_file();
 				WriteConfigFile();
 			}


### PR DESCRIPTION
Unrealted..

----

🎯 **What:** Fixed a buffer overflow vulnerability in `d1/main/inferno.c` and `d2/main/inferno.c` where the pilot name from the command line could overflow the `Players[Player_num].callsign` buffer.
⚠️ **Risk:** The `callsign` buffer is 9 bytes long (8 chars + null), but the code was copying up to 12 characters from the filename derived from the command line argument `-pilot`. This could lead to memory corruption and potential code execution or crash.
🛡️ **Solution:** Replaced the unsafe `strcpy` with `snprintf(..., sizeof(...), "%s", ...)` to ensure the copied string is truncated to fit the destination buffer and is null-terminated. This aligns with the `CALLSIGN_LEN` limit of 8 characters.

Verified by:
- Created a reproduction script `reproduce_overflow.c` that demonstrated the overflow.
- Created `reproduce_fix.c` that verified the fix truncates the string safely.
- Compiled `d1` (standard build) successfully.
- Compiled `d2` (VR build) successfully. Note: `d2` standard build is currently broken in the repository due to unrelated issues in `gauges.c` and `gamerend.c` (unrelated to this change), so verification was done using the VR build configuration.

---
*PR created automatically by Jules for task [11367628540217727839](https://jules.google.com/task/11367628540217727839) started by @arran4*