### PR TITLE
Fix buffer overflow in player callsign handling

### DIFF
--- a/d1/main/inferno.c
+++ b/d1/main/inferno.c
@@ -457,8 +457,10 @@ int main(int argc, char *argv[])
 				strcat(filename,".plr");
 			if(PHYSFSX_exists(filename,0))
 			{
+				char *src;
 				strcpy(strstr(filename,".plr"),"\0");
-				strcpy(Players[Player_num].callsign, GameArg.SysUsePlayersDir? &filename[8] : filename);
+				src = GameArg.SysUsePlayersDir? &filename[8] : filename;
+				snprintf(Players[Player_num].callsign, CALLSIGN_LEN + 1, "%s", src);
 				read_player_file();
 				WriteConfigFile();
 			}


### PR DESCRIPTION
I guess it does something.
 
---

Fixed a buffer overflow vulnerability in `d1/main/inferno.c` where a long pilot name from command line arguments could overflow the `callsign` buffer. Replaced `strcpy` with `snprintf` to strictly limit the copy to `CALLSIGN_LEN` characters. Validated the fix with a reproduction script and confirmed successful build.

---
*PR created automatically by Jules for task [11590251185410132782](https://jules.google.com/task/11590251185410132782) started by @arran4*