### PR TITLE
Render menus to SDL window during VR menu submission

### DIFF
--- a/d2/arch/sdl/event.c
+++ b/d2/arch/sdl/event.c
@@ -236,11 +236,28 @@ void event_process(void)
 		}
 
 	}
-	for (int eye = 0; eye < 2; eye++) {
-		if (Screen_mode == SCREEN_GAME)
+	if (Screen_mode == SCREEN_GAME) {
+		for (int eye = 0; eye < 2; eye++) {
 			vr_openvr_bind_eye(eye);
-		else if (use_vr_menu)
-			vr_openvr_bind_menu_target();
+			wind = window_get_first();
+			while (wind != NULL)
+			{
+				window *prev = window_get_prev(wind);
+				if (window_is_visible(wind))
+					window_send_event(wind, &event);
+				if (!window_exists(wind))
+				{
+					if (!prev) // well there isn't a previous window ...
+						break; // ... just bail out - we've done everything for this frame we can.
+					wind = window_get_next(prev); // the current window seemed to be closed. so take the next one from the previous which should be able to point to the one after the current closed
+				}
+				else
+					wind = window_get_next(wind);
+			}
+			vr_openvr_unbind_eye();
+		}
+		vr_openvr_submit_eyes();
+	} else {
 		wind = window_get_first();
 		while (wind != NULL)
 		{
@@ -256,17 +273,29 @@ void event_process(void)
 			else
 				wind = window_get_next(wind);
 		}
-		if (Screen_mode == SCREEN_GAME) {
-			vr_openvr_unbind_eye();
-		} else if (use_vr_menu) {
+
+		if (use_vr_menu)
+		{
+			vr_openvr_bind_menu_target();
+			wind = window_get_first();
+			while (wind != NULL)
+			{
+				window *prev = window_get_prev(wind);
+				if (window_is_visible(wind))
+					window_send_event(wind, &event);
+				if (!window_exists(wind))
+				{
+					if (!prev) // well there isn't a previous window ...
+						break; // ... just bail out - we've done everything for this frame we can.
+					wind = window_get_next(prev); // the current window seemed to be closed. so take the next one from the previous which should be able to point to the one after the current closed
+				}
+				else
+					wind = window_get_next(wind);
+			}
 			vr_openvr_unbind_menu_target();
-			break;
+			vr_openvr_submit_menu(1);
 		}
 	}
-	if (Screen_mode == SCREEN_GAME)
-		vr_openvr_submit_eyes();
-	else if (use_vr_menu)
-		vr_openvr_submit_menu(1);
 
 	gr_flip();
 #ifdef OGL


### PR DESCRIPTION
### Motivation
- Menus rendered for the VR headset were leaving the SDL2 desktop window black; the intent is to keep the desktop window updated while still submitting menus/textures to the VR compositor.
- Ensure both desktop and VR targets receive the menu draw pass so the SDL window mirrors the visible UI.

### Description
- Updated `event_process` flow in `d1/arch/sdl/event.c` and `d2/arch/sdl/event.c` to perform two rendering passes: one for the desktop SDL window and one for the VR menu target when `use_vr_menu` is active.
- When `Screen_mode == SCREEN_GAME` the code now iterates per-eye, calling `vr_openvr_bind_eye`/`vr_openvr_unbind_eye` for each eye and then `vr_openvr_submit_eyes` after the two-eye pass to preserve existing VR eye rendering.
- When not in game mode the code renders the desktop window first, then, if `use_vr_menu` is true, binds the VR menu target via `vr_openvr_bind_menu_target`, renders the windows again to that target, unbinds and calls `vr_openvr_submit_menu(1)`.
- Changes confined to `d1/arch/sdl/event.c` and `d2/arch/sdl/event.c` and keep existing `vr_openvr_begin_frame` / render-size logic intact.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f47f7b948330bdc6a9f033f5e1d5)